### PR TITLE
chore: update protocol references to v0.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ sdk/typescript-sdk/    # Core packages
 bridge/             # MCP-MEW bridge
 cli/               # Command-line tool
 tests/             # Integration tests (scenario-*)
-spec/              # Protocol specs (v0.3=current, draft=next)
+spec/              # Protocol specs (v0.4=current, draft=next)
 docs/              # Guides in architecture/, guides/, bugs/, progress/
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ sdk/typescript-sdk/    # Core packages
 bridge/             # MCP-MEW bridge
 cli/               # Command-line tool
 tests/             # Integration tests (scenario-*)
-spec/              # Protocol specs (v0.3=current, draft=next)
+spec/              # Protocol specs (v0.4=current, draft=next)
 docs/              # Guides in architecture/, guides/, bugs/, progress/
 ```
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,13 @@
+# MEW Protocol v0.4 Migration Notes
+
+The repository now references the v0.4 protocol specification. The following implementation gaps remain and should be addressed in follow-up work before claiming full compliance with the v0.4 MEW Protocol.
+
+## CLI
+- The built-in `client connect` and `agent start` workflows still send a legacy `{ type: 'join' }` handshake instead of a v0.4 MEW envelope. The gateway continues to translate this legacy format, but participants should emit full envelopes going forward.
+- `gateway` back-fills envelope fields (protocol, id, timestamps) when participants omit them. Under the v0.4 spec every message on the wire should already be a complete envelope.
+- The note-taker template agent uses the rejected `system/join` message kind. A compliant join/authorization sequence needs to be defined for v0.4.
+
+## SDK
+- The shared `Envelope` type still allows `correlation_id` to be a single string for backward compatibility, whereas v0.4 requires an array of strings. Client code should emit arrays once the ecosystem is ready.
+
+If additional incompatibilities are discovered while adopting the v0.4 protocol, add them here so the work can be prioritized.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The **proposal mechanism** ensures humans stay in control. New agents start with
 
 ## 📦 Current Version
 
-**v0.3** - Released 2025-01-09 🎉
+**v0.4** - Released 2025-09-26 🎉
 
-MEW Protocol is in experimental phase (v0.x) with breaking changes allowed between versions. See [spec/v0.3/SPEC.md](/spec/v0.3/SPEC.md) for the current specification.
+MEW Protocol is in experimental phase (v0.x) with breaking changes allowed between versions. See [spec/v0.4/SPEC.md](/spec/v0.4/SPEC.md) for the current specification.
 
 ## 🚀 Quick Start
 
@@ -89,9 +89,9 @@ That's it! MEW guides you through setting up your workspace with:
 
 ## 📚 Learn More
 
-- 📋 [Current Specification (v0.3)](/spec/v0.3/SPEC.md)
+- 📋 [Current Specification (v0.4)](/spec/v0.4/SPEC.md)
 - 📝 [Draft Specification (next version)](/spec/draft/SPEC.md)
-- 🏗️ [Architecture Decision Records](/spec/v0.3/decisions/)
+- 🏗️ [Architecture Decision Records](/spec/v0.4/decisions/)
 - 📜 [Changelog](/CHANGELOG.md)
 
 ## 🐈 Why "MEW"?

--- a/bridge/spec/draft/SPEC.md
+++ b/bridge/spec/draft/SPEC.md
@@ -35,7 +35,7 @@ Out of scope:
 MEW Space
     │
     ├── Gateway (WebSocket)
-    │      ↕ MEW Protocol v0.3
+    │      ↕ MEW Protocol v0.4
     │
     ├── MCP Bridge Process (@mew-protocol/bridge)
     │   ├── MEWParticipant (SDK base class)
@@ -145,7 +145,7 @@ Identifies this participant as an MCP bridge (required for gateway to use bridge
 ```javascript
 // MEW Request (incoming)
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "req-123",
   "from": "client",
   "to": ["filesystem"],
@@ -164,7 +164,7 @@ Identifies this participant as an MCP bridge (required for gateway to use bridge
 ```javascript
 // MEW Request (incoming)
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "req-456",
   "from": "client",
   "to": ["filesystem"],
@@ -200,7 +200,7 @@ Identifies this participant as an MCP bridge (required for gateway to use bridge
 
 // MEW Response (automatic from MEWParticipant)
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "resp-789",
   "from": "filesystem",
   "to": ["client"],
@@ -437,7 +437,7 @@ Log categories:
 
 ## References
 
-- [MEW Protocol Specification v0.3](../../spec/v0.3/SPEC.md)
+- [MEW Protocol Specification v0.4](../../spec/v0.4/SPEC.md)
 - [MCP Specification](https://modelcontextprotocol.org)
 - [MEW SDK Documentation](../../sdk/spec/draft/SPEC.md)
 - [Test Scenarios](../../tests/scenario-7-mcp-bridge/)

--- a/cli/spec/CHANGELOG.md
+++ b/cli/spec/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Changed
 - Updated all references from MEUP to MEW protocol
-- Updated protocol version from v0.2 to v0.3
+- Updated protocol version from v0.2 to v0.4
 - Enhanced participant resolution with multiple fallback strategies
 
 ### Features

--- a/cli/spec/draft/SPEC.md
+++ b/cli/spec/draft/SPEC.md
@@ -760,7 +760,7 @@ ls -la .mew/tokens/
 
 ## FIFO Message Format
 
-Messages sent to/from FIFOs use MEW v0.3 protocol format.
+Messages sent to/from FIFOs use MEW v0.4 protocol format.
 
 **Input (to fifo-in):**
 Simplified format - CLI adds protocol envelope fields:
@@ -774,10 +774,10 @@ Simplified format - CLI adds protocol envelope fields:
 ```
 
 **Output (from fifo-out):**
-Full MEW v0.3 envelope:
+Full MEW v0.4 envelope:
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-123",
   "ts": "2025-01-05T12:00:00Z",
   "from": "other-agent",
@@ -897,7 +897,7 @@ defaults:
 
 #### Capability Patterns
 
-Capabilities use JSON pattern matching as defined in MEW v0.3:
+Capabilities use JSON pattern matching as defined in MEW v0.4:
 
 **Simple patterns:**
 ```yaml

--- a/cli/spec/draft/decisions/accepted/005-iui-interactive-ui-architecture.md
+++ b/cli/spec/draft/decisions/accepted/005-iui-interactive-ui-architecture.md
@@ -27,9 +27,9 @@ This debug mode should be:
 
 Show only JSON messages, require full JSON input:
 ```
-< {"protocol":"mew/v0.3","kind":"system/welcome",...}
-> {"protocol":"mew/v0.3","kind":"chat","payload":{"text":"hello"}}
-< {"protocol":"mew/v0.3","kind":"chat","from":"echo",...}
+< {"protocol":"mew/v0.4","kind":"system/welcome",...}
+> {"protocol":"mew/v0.4","kind":"chat","payload":{"text":"hello"}}
+< {"protocol":"mew/v0.4","kind":"chat","from":"echo",...}
 ```
 
 **Pros:**
@@ -174,7 +174,7 @@ Verbose mode (`/verbose` command) shows full JSON:
 ```
 [10:23:45] → you chat
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-123",
   "kind": "chat",
   "payload": {"text": "Hello"}
@@ -335,7 +335,7 @@ Active participants:
 > {"kind": "invalid"}
 [10:25:00] → you invalid
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-456",
   "ts": "2025-01-10T10:25:00Z",
   "from": "human",
@@ -344,7 +344,7 @@ Active participants:
 
 [10:25:01] ← system system/error
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "kind": "system/error",
   "payload": {
     "error": "Unknown message kind: invalid",

--- a/cli/spec/draft/decisions/accepted/008-f4x-safe-fifo-input-mechanism.md
+++ b/cli/spec/draft/decisions/accepted/008-f4x-safe-fifo-input-mechanism.md
@@ -431,4 +431,4 @@ For backward compatibility, FIFO mode is still supported but not recommended for
 - [Express.js Documentation](https://expressjs.com/)
 - [Unix Domain Sockets](https://man7.org/linux/man-pages/man7/unix.7.html)
 - [MEW CLI Specification](../SPEC.md)
-- [MEW Protocol v0.3 Specification](../../../../spec/v0.3/SPEC.md)
+- [MEW Protocol v0.4 Specification](../../../../spec/v0.4/SPEC.md)

--- a/cli/spec/draft/decisions/accepted/009-aud-approval-dialog-ux.md
+++ b/cli/spec/draft/decisions/accepted/009-aud-approval-dialog-ux.md
@@ -182,7 +182,7 @@ This ensures users always know:
 When user selects "Yes, allow all X during this session", the CLI sends a capability grant message:
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "from": "human",
   "to": ["coder-agent"],
   "kind": "capability/grant",
@@ -452,7 +452,7 @@ function ProposalDialog({ proposal, onApprove, onDeny, sessionPermissions }) {
       case 2:
         // Grant capability for all similar operations
         const grant = {
-          protocol: "mew/v0.3",
+          protocol: "mew/v0.4",
           from: participantId,
           to: [proposal.from],
           kind: "capability/grant",

--- a/cli/spec/draft/proposed/ADR-002-hybrid-transport-websocket-http.md
+++ b/cli/spec/draft/proposed/ADR-002-hybrid-transport-websocket-http.md
@@ -47,7 +47,7 @@ Content-Type: application/json
 ```
 
 The gateway adds protocol envelope fields:
-- `protocol: "mew/v0.3"`
+- `protocol: "mew/v0.4"`
 - `id: "http-${timestamp}-${random}"`
 - `ts: "${iso8601_timestamp}"`
 - `from: "${participantId}"`
@@ -89,7 +89,7 @@ app.post('/participants/:participantId/messages', (req, res) => {
   
   // Build complete envelope
   const envelope = {
-    protocol: 'mew/v0.3',
+    protocol: 'mew/v0.4',
     id: `http-${Date.now()}-${randomId()}`,
     ts: new Date().toISOString(),
     from: participantId,

--- a/cli/spec/draft/proposed/ADR-005-join-message-protocol-inconsistency.md
+++ b/cli/spec/draft/proposed/ADR-005-join-message-protocol-inconsistency.md
@@ -5,7 +5,7 @@ Proposed
 
 ## Context
 
-The current implementation has a significant inconsistency in how participants join spaces. The MEW Protocol v0.3 specification does not define a join mechanism, leaving it as an implementation detail. However, the CLI implementation uses **two different join message formats** inconsistently across different components.
+The current implementation has a significant inconsistency in how participants join spaces. The MEW Protocol v0.4 specification does not define a join mechanism, leaving it as an implementation detail. However, the CLI implementation uses **two different join message formats** inconsistently across different components.
 
 ### Current Implementation Issues:
 
@@ -13,7 +13,7 @@ The current implementation has a significant inconsistency in how participants j
 ```javascript
 // Used in client.js and agent.js
 {
-  type: 'join',                    // NOT MEW v0.3 compliant
+  type: 'join',                    // NOT MEW v0.4 compliant
   participantId: 'participant-id',
   space: 'space-name',
   token: 'auth-token'
@@ -24,7 +24,7 @@ The current implementation has a significant inconsistency in how participants j
 ```javascript
 // Used in space.js for interactive connections
 {
-  protocol: 'mew/v0.3',           // MEW v0.3 compliant envelope
+  protocol: 'mew/v0.4',           // MEW v0.4 compliant envelope
   id: 'join-12345',
   ts: '2025-01-10T12:00:00Z',
   kind: 'system/join',
@@ -49,12 +49,12 @@ This creates confusion, maintenance burden, and protocol compliance issues.
 
 ## Decision
 
-We will **standardize on the MEW v0.3 compliant `system/join` envelope format** and deprecate the legacy `type: 'join'` format.
+We will **standardize on the MEW v0.4 compliant `system/join` envelope format** and deprecate the legacy `type: 'join'` format.
 
 ### Standard Join Message Format:
 ```javascript
 {
-  protocol: 'mew/v0.3',
+  protocol: 'mew/v0.4',
   id: `join-${uuidv4()}`,
   ts: new Date().toISOString(),
   from: participantId,              // NEW: sender identification
@@ -69,7 +69,7 @@ We will **standardize on the MEW v0.3 compliant `system/join` envelope format** 
 ```
 
 ### Rationale for MEW Compliance:
-1. **Protocol Consistency**: All messages follow MEW v0.3 envelope format
+1. **Protocol Consistency**: All messages follow MEW v0.4 envelope format
 2. **Future Compatibility**: Aligns with protocol evolution
 3. **Tooling Compatibility**: Works with MEW protocol analyzers
 4. **Audit Trail**: Standard envelope provides tracking fields (`id`, `ts`, `from`)
@@ -80,7 +80,7 @@ We will **standardize on the MEW v0.3 compliant `system/join` envelope format** 
 ```javascript
 // Gateway continues accepting both formats during transition
 if (message.kind === 'system/join') {
-  // Standard MEW v0.3 format (preferred)
+  // Standard MEW v0.4 format (preferred)
   handleMEWJoin(message);
 } else if (message.type === 'join') {
   // Legacy format (deprecated, with warning)
@@ -105,9 +105,9 @@ ws.send(JSON.stringify({
   token: options.token,
 }));
 
-// AFTER (MEW v0.3 compliant)  
+// AFTER (MEW v0.4 compliant)  
 const joinMessage = {
-  protocol: 'mew/v0.3',
+  protocol: 'mew/v0.4',
   id: `join-${Date.now()}`,
   ts: new Date().toISOString(),
   from: participantId,
@@ -129,7 +129,7 @@ ws.send(JSON.stringify(joinMessage));
 ### Phase 3: Gateway Cleanup
 Remove legacy format support after transition period:
 ```javascript
-// Only accept MEW v0.3 compliant format
+// Only accept MEW v0.4 compliant format
 if (message.kind === 'system/join') {
   handleJoin(message);
 } else {
@@ -139,7 +139,7 @@ if (message.kind === 'system/join') {
 
 ## Protocol Extension Consideration
 
-Since MEW Protocol v0.3 does not define join semantics, this is effectively a **protocol extension** that should be documented.
+Since MEW Protocol v0.4 does not define join semantics, this is effectively a **protocol extension** that should be documented.
 
 ### Proposed MEW Protocol Extension:
 ```
@@ -206,9 +206,9 @@ Month 7+: Remove legacy format support
 ### Format Validation Tests:
 ```javascript
 describe('Join Message Handling', () => {
-  test('accepts MEW v0.3 compliant join', () => {
+  test('accepts MEW v0.4 compliant join', () => {
     const message = {
-      protocol: 'mew/v0.3',
+      protocol: 'mew/v0.4',
       id: 'join-123',
       ts: new Date().toISOString(),
       from: 'test-participant',
@@ -247,7 +247,7 @@ Send a join message to connect:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "join-unique-id",
   "ts": "2025-01-10T12:00:00Z", 
   "from": "your-participant-id",
@@ -275,7 +275,7 @@ Gateway responds with `system/welcome` containing your capabilities.
 **New Format (Required):**
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "kind": "system/join", 
   "payload": { "space": "...", "participant": "...", "token": "..." }
 }
@@ -302,7 +302,7 @@ Gateway responds with `system/welcome` containing your capabilities.
 ## Consequences
 
 ### Positive:
-- **Protocol Consistency**: All messages follow MEW v0.3 envelope
+- **Protocol Consistency**: All messages follow MEW v0.4 envelope
 - **Future Compatibility**: Aligned with protocol evolution
 - **Maintainability**: Single format to test and support
 - **Tooling**: Standard MEW analyzers can parse join messages

--- a/cli/spec/draft/proposed/README.md
+++ b/cli/spec/draft/proposed/README.md
@@ -1,6 +1,6 @@
 # MEW CLI Architecture Decision Records (ADRs)
 
-This directory contains Architecture Decision Records (ADRs) that document key architectural and design decisions made during the implementation of the MEW CLI, particularly where the implementation diverges from or extends the MEW Protocol v0.3 specification.
+This directory contains Architecture Decision Records (ADRs) that document key architectural and design decisions made during the implementation of the MEW CLI, particularly where the implementation diverges from or extends the MEW Protocol v0.4 specification.
 
 ## Status: Proposed
 All ADRs in this directory are currently **proposed** and under review. They document the current state of the CLI implementation and the rationale behind key architectural choices.
@@ -60,12 +60,12 @@ All ADRs in this directory are currently **proposed** and under review. They doc
 ---
 
 ### [ADR-005: Join Message Protocol Inconsistency](./ADR-005-join-message-protocol-inconsistency.md)
-**Decision**: Standardize on MEW v0.3 compliant `system/join` envelope format and deprecate legacy `type: 'join'` format.
+**Decision**: Standardize on MEW v0.4 compliant `system/join` envelope format and deprecate legacy `type: 'join'` format.
 
 **Context**: The implementation currently uses two different join message formats inconsistently across components, creating protocol compliance and maintenance issues.
 
 **Impact**:
-- ✅ Protocol consistency with MEW v0.3 envelope format
+- ✅ Protocol consistency with MEW v0.4 envelope format
 - ✅ Future compatibility and tooling support
 - ⚠️ Breaking change requiring client migration
 - ⚠️ Temporary dual-format complexity during transition
@@ -97,7 +97,7 @@ The ADRs collectively document a **layered architecture** that separates protoco
 ## Key Design Principles
 
 ### 1. **Protocol Compliance with Operational Extensions**
-- Core message exchange follows MEW Protocol v0.3
+- Core message exchange follows MEW Protocol v0.4
 - Operational features (process management, configuration) are implementation extensions
 - Clear separation between protocol semantics and deployment concerns
 
@@ -164,7 +164,7 @@ To propose changes or add new ADRs:
 
 ## Links
 
-- [MEW Protocol v0.3 Specification](../../../spec/v0.3/SPEC.md)
+- [MEW Protocol v0.4 Specification](../../../spec/v0.4/SPEC.md)
 - [CLI Draft Specification](../SPEC.md) 
 - [Implementation Source Code](../../../src/)
 - [Test Scenarios](../../../tests/)

--- a/cli/spec/v0.1.0/SPEC.md
+++ b/cli/spec/v0.1.0/SPEC.md
@@ -161,7 +161,7 @@ mew token create \
 
 ## FIFO Message Format
 
-Messages sent to/from FIFOs use MEW v0.3 protocol format.
+Messages sent to/from FIFOs use MEW v0.4 protocol format.
 
 **Input (to fifo-in):**
 Simplified format - CLI adds protocol envelope fields:
@@ -175,10 +175,10 @@ Simplified format - CLI adds protocol envelope fields:
 ```
 
 **Output (from fifo-out):**
-Full MEW v0.3 envelope:
+Full MEW v0.4 envelope:
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-123",
   "ts": "2025-01-05T12:00:00Z",
   "from": "other-agent",
@@ -293,7 +293,7 @@ defaults:
 
 #### Capability Patterns
 
-Capabilities use JSON pattern matching as defined in MEW v0.3:
+Capabilities use JSON pattern matching as defined in MEW v0.4:
 
 **Simple patterns:**
 ```yaml

--- a/cli/spec/v0.1.0/decisions/accepted/005-iui-interactive-ui-architecture.md
+++ b/cli/spec/v0.1.0/decisions/accepted/005-iui-interactive-ui-architecture.md
@@ -20,9 +20,9 @@ This is explicitly NOT trying to be a polished chat interface or sophisticated c
 
 Show only JSON messages, require full JSON input:
 ```
-< {"protocol":"mew/v0.3","kind":"system/welcome",...}
-> {"protocol":"mew/v0.3","kind":"chat","payload":{"text":"hello"}}
-< {"protocol":"mew/v0.3","kind":"chat","from":"echo",...}
+< {"protocol":"mew/v0.4","kind":"system/welcome",...}
+> {"protocol":"mew/v0.4","kind":"chat","payload":{"text":"hello"}}
+< {"protocol":"mew/v0.4","kind":"chat","from":"echo",...}
 ```
 
 **Pros:**
@@ -167,7 +167,7 @@ Verbose mode (`/verbose` command) shows full JSON:
 ```
 [10:23:45] → you chat
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-123",
   "kind": "chat",
   "payload": {"text": "Hello"}
@@ -328,7 +328,7 @@ Active participants:
 > {"kind": "invalid"}
 [10:25:00] → you invalid
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-456",
   "ts": "2025-01-10T10:25:00Z",
   "from": "human",
@@ -337,7 +337,7 @@ Active participants:
 
 [10:25:01] ← system system/error
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "kind": "system/error",
   "payload": {
     "error": "Unknown message kind: invalid",

--- a/cli/src/commands/gateway-enhanced.js
+++ b/cli/src/commands/gateway-enhanced.js
@@ -101,7 +101,7 @@ gateway
       }
 
       // Protocol version check
-      if (message.protocol && message.protocol !== 'mew/v0.3') {
+      if (message.protocol && message.protocol !== 'mew/v0.4') {
         return `Invalid protocol version: ${message.protocol}`;
       }
 
@@ -135,7 +135,7 @@ gateway
           if (validationError) {
             ws.send(
               JSON.stringify({
-                protocol: 'mew/v0.3',
+                protocol: 'mew/v0.4',
                 kind: 'system/error',
                 payload: {
                   error: validationError,
@@ -176,7 +176,7 @@ gateway
             // Send welcome message with capabilities
             ws.send(
               JSON.stringify({
-                protocol: 'mew/v0.3',
+                protocol: 'mew/v0.4',
                 kind: 'system/welcome',
                 payload: {
                   participantId,
@@ -195,7 +195,7 @@ gateway
           if (requiredCapability && !hasCapability(participantId, requiredCapability)) {
             ws.send(
               JSON.stringify({
-                protocol: 'mew/v0.3',
+                protocol: 'mew/v0.4',
                 kind: 'system/error',
                 payload: {
                   error: `Insufficient capability: ${requiredCapability} required`,
@@ -239,7 +239,7 @@ gateway
                 : message.correlation_id;
 
             const envelope = {
-              protocol: 'mew/v0.3',
+              protocol: 'mew/v0.4',
               id: `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
               ts: new Date().toISOString(),
               from: participantId,
@@ -268,7 +268,7 @@ gateway
           console.error('Error handling message:', error);
           ws.send(
             JSON.stringify({
-              protocol: 'mew/v0.3',
+              protocol: 'mew/v0.4',
               kind: 'system/error',
               payload: {
                 error: error.message,
@@ -312,7 +312,7 @@ function handleCapabilityGrant(message, ws, fromParticipant, spaces, capabilitie
   if (!hasCapability(fromParticipant, 'capability/admin')) {
     ws.send(
       JSON.stringify({
-        protocol: 'mew/v0.3',
+        protocol: 'mew/v0.4',
         kind: 'system/error',
         payload: {
           error: 'Not authorized to grant capabilities',
@@ -339,7 +339,7 @@ function handleCapabilityGrant(message, ws, fromParticipant, spaces, capabilitie
     if (targetWs && targetWs.readyState === WebSocket.OPEN) {
       targetWs.send(
         JSON.stringify({
-          protocol: 'mew/v0.3',
+          protocol: 'mew/v0.4',
           kind: 'capability/granted',
           from: fromParticipant,
           payload: {
@@ -362,7 +362,7 @@ function handleCapabilityRevoke(message, ws, fromParticipant, spaces, capabiliti
   if (!hasCapability(fromParticipant, 'capability/admin')) {
     ws.send(
       JSON.stringify({
-        protocol: 'mew/v0.3',
+        protocol: 'mew/v0.4',
         kind: 'system/error',
         payload: {
           error: 'Not authorized to revoke capabilities',
@@ -390,7 +390,7 @@ function handleCapabilityRevoke(message, ws, fromParticipant, spaces, capabiliti
     if (targetWs && targetWs.readyState === WebSocket.OPEN) {
       targetWs.send(
         JSON.stringify({
-          protocol: 'mew/v0.3',
+          protocol: 'mew/v0.4',
           kind: 'capability/revoked',
           from: fromParticipant,
           payload: {
@@ -423,7 +423,7 @@ function handleContextPush(message, ws, participantId, contextStacks, spaces, op
   if (ws.spaceId && spaces.has(ws.spaceId)) {
     const space = spaces.get(ws.spaceId);
     const envelope = {
-      protocol: 'mew/v0.3',
+      protocol: 'mew/v0.4',
       id: `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
       ts: new Date().toISOString(),
       from: participantId,
@@ -451,7 +451,7 @@ function handleContextPop(message, ws, participantId, contextStacks, spaces, opt
   if (stack.length === 0) {
     ws.send(
       JSON.stringify({
-        protocol: 'mew/v0.3',
+        protocol: 'mew/v0.4',
         kind: 'system/error',
         payload: {
           error: 'No context to pop',
@@ -468,7 +468,7 @@ function handleContextPop(message, ws, participantId, contextStacks, spaces, opt
   if (ws.spaceId && spaces.has(ws.spaceId)) {
     const space = spaces.get(ws.spaceId);
     const envelope = {
-      protocol: 'mew/v0.3',
+      protocol: 'mew/v0.4',
       id: `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
       ts: new Date().toISOString(),
       from: participantId,

--- a/cli/src/commands/gateway-original.js
+++ b/cli/src/commands/gateway-original.js
@@ -74,7 +74,7 @@ gateway
             // Send welcome message
             ws.send(
               JSON.stringify({
-                protocol: 'mew/v0.3',
+                protocol: 'mew/v0.4',
                 kind: 'system/welcome',
                 payload: {
                   participantId,
@@ -92,7 +92,7 @@ gateway
           if (spaceId && spaces.has(spaceId)) {
             const space = spaces.get(spaceId);
             const envelope = {
-              protocol: 'mew/v0.3',
+              protocol: 'mew/v0.4',
               id: `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
               ts: new Date().toISOString(),
               from: participantId,
@@ -114,7 +114,7 @@ gateway
           console.error('Error handling message:', error);
           ws.send(
             JSON.stringify({
-              protocol: 'mew/v0.3',
+              protocol: 'mew/v0.4',
               kind: 'system/error',
               payload: {
                 error: error.message,

--- a/cli/src/commands/gateway.js
+++ b/cli/src/commands/gateway.js
@@ -154,7 +154,7 @@ gateway
 
       // Build complete envelope
       const envelope = {
-        protocol: 'mew/v0.3',
+        protocol: 'mew/v0.4',
         id: `http-${Date.now()}-${Math.random().toString(36).substring(7)}`,
         ts: new Date().toISOString(),
         from: participantId,
@@ -549,7 +549,7 @@ gateway
       }
 
       // Protocol version check
-      if (message.protocol && message.protocol !== 'mew/v0.3') {
+      if (message.protocol && message.protocol !== 'mew/v0.4') {
         return `Invalid protocol version: ${message.protocol}`;
       }
 
@@ -610,7 +610,7 @@ gateway
           if (validationError) {
             ws.send(
               JSON.stringify({
-                protocol: 'mew/v0.3',
+                protocol: 'mew/v0.4',
                 kind: 'system/error',
                 payload: {
                   error: validationError,
@@ -655,7 +655,7 @@ gateway
 
             // Send welcome message per MEW v0.2 spec
             const welcomeMessage = {
-              protocol: 'mew/v0.3',
+              protocol: 'mew/v0.4',
               id: `welcome-${Date.now()}`,
               ts: new Date().toISOString(),
               from: 'system:gateway',
@@ -679,7 +679,7 @@ gateway
 
             // Broadcast presence to others
             const presenceMessage = {
-              protocol: 'mew/v0.3',
+              protocol: 'mew/v0.4',
               id: `presence-${Date.now()}`,
               ts: new Date().toISOString(),
               from: 'system:gateway',
@@ -715,7 +715,7 @@ gateway
             const requestedCapabilities = message.payload?.capabilities;
             if (!Array.isArray(requestedCapabilities)) {
               const errorMessage = {
-                protocol: 'mew/v0.3',
+                protocol: 'mew/v0.4',
                 id: `error-${Date.now()}`,
                 ts: new Date().toISOString(),
                 from: 'system:gateway',
@@ -744,7 +744,7 @@ gateway
             const space = spaces.get(spaceId);
             if (space) {
               const presenceUpdate = {
-                protocol: 'mew/v0.3',
+                protocol: 'mew/v0.4',
                 id: `presence-${Date.now()}`,
                 ts: new Date().toISOString(),
                 from: 'system:gateway',
@@ -771,7 +771,7 @@ gateway
           // Check capabilities for non-join messages
           if (!(await hasCapabilityForMessage(participantId, message))) {
             const errorMessage = {
-              protocol: 'mew/v0.3',
+              protocol: 'mew/v0.4',
               id: `error-${Date.now()}`,
               ts: new Date().toISOString(),
               from: 'system:gateway',
@@ -801,7 +801,7 @@ gateway
             });
             if (!canGrant) {
               const errorMessage = {
-                protocol: 'mew/v0.3',
+                protocol: 'mew/v0.4',
                 id: `error-${Date.now()}`,
                 ts: new Date().toISOString(),
                 from: 'system:gateway',
@@ -845,7 +845,7 @@ gateway
               const recipientWs = space?.participants.get(recipient);
               if (recipientWs && recipientWs.readyState === WebSocket.OPEN) {
                 const ackMessage = {
-                  protocol: 'mew/v0.3',
+                  protocol: 'mew/v0.4',
                   id: `ack-${Date.now()}`,
                   ts: new Date().toISOString(),
                   from: 'system:gateway',
@@ -871,7 +871,7 @@ gateway
                 const updatedCapabilities = [...staticCapabilities, ...dynamicCapabilities];
 
                 const updatedWelcomeMessage = {
-                  protocol: 'mew/v0.3',
+                  protocol: 'mew/v0.4',
                   id: `welcome-update-${Date.now()}`,
                   ts: new Date().toISOString(),
                   from: 'system:gateway',
@@ -909,7 +909,7 @@ gateway
             });
             if (!canRevoke) {
               const errorMessage = {
-                protocol: 'mew/v0.3',
+                protocol: 'mew/v0.4',
                 id: `error-${Date.now()}`,
                 ts: new Date().toISOString(),
                 from: 'system:gateway',
@@ -974,7 +974,7 @@ gateway
 
           // Add protocol envelope fields if missing
           const envelope = {
-            protocol: message.protocol || 'mew/v0.3',
+            protocol: message.protocol || 'mew/v0.4',
             id: message.id || `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
             ts: message.ts || new Date().toISOString(),
             from: participantId,
@@ -1004,7 +1004,7 @@ gateway
 
             // Send stream/open response
             const streamOpenResponse = {
-              protocol: 'mew/v0.3',
+              protocol: 'mew/v0.4',
               id: `stream-open-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
               ts: new Date().toISOString(),
               from: 'gateway',
@@ -1073,7 +1073,7 @@ gateway
           console.error('Error handling message:', error);
           ws.send(
             JSON.stringify({
-              protocol: 'mew/v0.3',
+              protocol: 'mew/v0.4',
               kind: 'system/error',
               payload: {
                 error: error.message,
@@ -1098,7 +1098,7 @@ gateway
 
           // Broadcast leave presence
           const presenceMessage = {
-            protocol: 'mew/v0.3',
+            protocol: 'mew/v0.4',
             id: `presence-${Date.now()}`,
             ts: new Date().toISOString(),
             from: 'system:gateway',

--- a/cli/src/commands/space.js
+++ b/cli/src/commands/space.js
@@ -800,7 +800,7 @@ async function spaceUpAction(options) {
         ws.on('open', () => {
           // Send join message
           const joinMessage = {
-            protocol: 'mew/v0.3',
+            protocol: 'mew/v0.4',
             id: `join-${Date.now()}`,
             ts: new Date().toISOString(),
             kind: 'system/join',
@@ -1459,7 +1459,7 @@ space
       ws.on('open', () => {
         // Send join message
         const joinMessage = {
-          protocol: 'mew/v0.3',
+          protocol: 'mew/v0.4',
           id: `join-${Date.now()}`,
           ts: new Date().toISOString(),
           kind: 'system/join',

--- a/cli/src/utils/advanced-interactive-ui.js
+++ b/cli/src/utils/advanced-interactive-ui.js
@@ -4,7 +4,7 @@
  * Provides a modern terminal interface with native scrolling, MCP confirmations,
  * and rich formatting for MEW protocol interactions.
  * 
- * Based on Gemini CLI patterns and MEW Protocol v0.3 specification.
+ * Based on Gemini CLI patterns and MEW Protocol v0.4 specification.
  */
 
 const React = require('react');
@@ -722,7 +722,7 @@ function AdvancedInteractiveUI({ ws, participantId, spaceId }) {
     }
 
     // Check if this is an MCP proposal requiring confirmation
-    // In MEW v0.3, mcp/proposal contains operation details that need approval
+    // In MEW v0.4, mcp/proposal contains operation details that need approval
     if (message.kind === 'mcp/proposal') {
       // Check if we've already granted this capability
       const proposerGrants = grantedCapabilities.get(message.from) || [];
@@ -1338,7 +1338,7 @@ function AdvancedInteractiveUI({ ws, participantId, spaceId }) {
 
   const wrapEnvelope = (message) => {
     return {
-      protocol: 'mew/v0.3',
+      protocol: 'mew/v0.4',
       id: `msg-${uuidv4()}`,
       ts: new Date().toISOString(),
       from: participantId,
@@ -1349,7 +1349,7 @@ function AdvancedInteractiveUI({ ws, participantId, spaceId }) {
   };
 
   const isValidEnvelope = (obj) => {
-    return obj && obj.protocol === 'mew/v0.3' && obj.id && obj.ts && obj.kind;
+    return obj && obj.protocol === 'mew/v0.4' && obj.id && obj.ts && obj.kind;
   };
 
   const isDockedLayout = layoutMode === 'docked';

--- a/cli/src/utils/banner.js
+++ b/cli/src/utils/banner.js
@@ -82,7 +82,7 @@ function generateBanner(options = {}) {
             ${bold}██║ ╚═╝ ██║███████╗╚███╔███╔╝${reset}
             ${bold}╚═╝     ╚═╝╚══════╝ ╚══╝╚══╝${reset}
 
-    ${green}Multi-Entity Workspace Protocol v0.3${reset}
+    ${green}Multi-Entity Workspace Protocol v0.4${reset}
     ${cyan}"${tagline}"${reset}
 `;
 

--- a/cli/src/utils/interactive-ui.js
+++ b/cli/src/utils/interactive-ui.js
@@ -427,7 +427,7 @@ class InteractiveUI {
    * @returns {boolean}
    */
   isValidEnvelope(obj) {
-    return obj && obj.protocol === 'mew/v0.3' && obj.id && obj.ts && obj.kind;
+    return obj && obj.protocol === 'mew/v0.4' && obj.id && obj.ts && obj.kind;
   }
 
   /**
@@ -437,7 +437,7 @@ class InteractiveUI {
    */
   wrapEnvelope(message) {
     return {
-      protocol: 'mew/v0.3',
+      protocol: 'mew/v0.4',
       id: `msg-${uuidv4()}`,
       ts: new Date().toISOString(),
       from: this.participantId,

--- a/cli/templates/note-taker/agents/assistant.js
+++ b/cli/templates/note-taker/agents/assistant.js
@@ -33,7 +33,7 @@ ws.on('open', () => {
 
   // Send join message
   const joinMessage = {
-    protocol: 'mew/v0.3',
+    protocol: 'mew/v0.4',
     id: `msg-${Date.now()}`,
     ts: new Date().toISOString(),
     from: participantId,
@@ -58,7 +58,7 @@ ws.on('message', (data) => {
     if (message.kind === 'chat' && message.from !== participantId) {
       setTimeout(() => {
         const response = {
-          protocol: 'mew/v0.3',
+          protocol: 'mew/v0.4',
           id: `msg-${Date.now()}`,
           ts: new Date().toISOString(),
           from: participantId,

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -259,7 +259,7 @@ Bridges MCP servers to MEW Protocol. Requires the participant package to be buil
 
 ## Additional Resources
 
-- [MEW Protocol Specification](spec/v0.3/SPEC.md)
+- [MEW Protocol Specification](spec/v0.4/SPEC.md)
 - [TypeScript SDK Documentation](sdk/typescript-sdk/README.md)
 - [Test Scenarios](tests/README.md)
 - [Architecture Decision Records](decisions/)

--- a/docs/guides/SPEC-GUIDE.md
+++ b/docs/guides/SPEC-GUIDE.md
@@ -293,29 +293,29 @@ Mark old versions as deprecated but keep for reference
 
 2. **Update Draft Spec**
    - Keep SPEC.md as starting point for next version
-   - Update version header to indicate next target (e.g., "draft for v0.3")
+   - Update version header to indicate next target (e.g., "draft for v0.4")
    - Remove completed work that won't carry forward
 
 3. **Add README Clarifications**
    ```bash
    # Add README to each decision folder explaining state
-   echo "# Proposed ADRs for v0.3" > spec/draft/decisions/proposed/README.md
-   echo "# No accepted ADRs for v0.3 yet" > spec/draft/decisions/accepted/README.md
-   echo "# No rejected ADRs for v0.3 yet" > spec/draft/decisions/rejected/README.md
+   echo "# Proposed ADRs for v0.4" > spec/draft/decisions/proposed/README.md
+   echo "# No accepted ADRs for v0.4 yet" > spec/draft/decisions/accepted/README.md
+   echo "# No rejected ADRs for v0.4 yet" > spec/draft/decisions/rejected/README.md
    ```
 
 ### Example Release Flow
 
 ```bash
-# 1. Release v0.2 from draft
-cp -r spec/draft spec/v0.2
-rmdir spec/v0.2/decisions/proposed
-# Edit spec/v0.2/SPEC.md to update version
+# 1. Release v0.4 from draft
+cp -r spec/draft spec/v0.4
+rmdir spec/v0.4/decisions/proposed
+# Edit spec/v0.4/SPEC.md to update version
 
-# 2. Prepare draft for v0.3
+# 2. Prepare draft for v0.5
 rm -rf spec/draft/decisions/accepted/*.md
 rm -rf spec/draft/decisions/rejected/*.md
-# Edit spec/draft/SPEC.md to indicate "draft for v0.3"
+# Edit spec/draft/SPEC.md to indicate "draft for v0.5"
 
 # 3. Continue development
 # New ADRs go in spec/draft/decisions/proposed/

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -152,7 +152,7 @@ Discover what tools the fileserver provides:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "test-1",
   "from": "human",
   "to": ["filesystem-server"],
@@ -170,7 +170,7 @@ Check what resources are exposed:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "test-2",
   "from": "human",
   "to": ["filesystem-server"],
@@ -188,7 +188,7 @@ List files in the current directory:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "test-3",
   "from": "human",
   "to": ["filesystem-server"],
@@ -212,7 +212,7 @@ Read contents of a specific file:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "test-4",
   "from": "human",
   "to": ["filesystem-server"],
@@ -236,7 +236,7 @@ Create or update a file:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "test-5",
   "from": "human",
   "to": ["filesystem-server"],
@@ -261,7 +261,7 @@ Get metadata about a file:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "test-6",
   "from": "human",
   "to": ["filesystem-server"],
@@ -285,7 +285,7 @@ Create a new directory:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "test-7",
   "from": "human",
   "to": ["filesystem-server"],
@@ -309,7 +309,7 @@ Move or rename a file:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "test-8",
   "from": "human",
   "to": ["filesystem-server"],
@@ -334,7 +334,7 @@ Delete a file:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "test-9",
   "from": "human",
   "to": ["filesystem-server"],
@@ -359,7 +359,7 @@ Successful responses should look like:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "resp-X",
   "from": "mcp-fs-bridge",
   "to": ["human"],
@@ -379,7 +379,7 @@ Error responses will have an `error` field instead of `result`:
 
 ```json
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "resp-X",
   "from": "mcp-fs-bridge",
   "to": ["human"],

--- a/docs/protocol-flow-comparison.md
+++ b/docs/protocol-flow-comparison.md
@@ -208,7 +208,7 @@ Agent      →   {kind: "chat", to: ["human"],                           → All
 ```json
 // Human → All (via gateway)
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-1",
   "from": "human",
   "kind": "chat",
@@ -217,7 +217,7 @@ Agent      →   {kind: "chat", to: ["human"],                           → All
 
 // Agent → MCP Server (via gateway)
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-2",
   "from": "agent",
   "to": ["mcp-server"],
@@ -235,7 +235,7 @@ Agent      →   {kind: "chat", to: ["human"],                           → All
 
 // MCP Server → Agent (via gateway)
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-3",
   "from": "mcp-server",
   "to": ["agent"],
@@ -329,7 +329,7 @@ Agent      →   {kind: "chat", to: ["human"],                           → All
 ```json
 // Agent → All (PROPOSAL, not request)
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-2",
   "from": "agent",
   "to": ["human"],
@@ -345,7 +345,7 @@ Agent      →   {kind: "chat", to: ["human"],                           → All
 
 // Human → MCP Server (FULFILLING the proposal)
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-3",
   "from": "human",
   "to": ["mcp-server"],

--- a/sdk/spec/draft/SPEC.md
+++ b/sdk/spec/draft/SPEC.md
@@ -654,7 +654,7 @@ When a chat message or MCP request arrives:
 ```typescript
 // Incoming MEW Protocol envelope
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "msg-123",
   "from": "user",
   "to": ["agent"],
@@ -672,7 +672,7 @@ If `reasoningEnabled: true`, emit reasoning start:
 ```typescript
 // Agent sends reasoning/start message
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "reason-001",
   "from": "agent",
   "kind": "reasoning/start",
@@ -727,7 +727,7 @@ Return a JSON object with:
 ```typescript
 // Agent emits reasoning/thought
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "thought-001",
   "from": "agent",
   "kind": "reasoning/thought",
@@ -743,7 +743,7 @@ Return a JSON object with:
 ```typescript
 // Agent sends MCP request (or proposal if lacking capability)
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "req-001",
   "from": "agent",
   "to": ["weather-service"],
@@ -762,7 +762,7 @@ Return a JSON object with:
 
 // Tool responds
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "resp-001",
   "from": "weather-service",
   "to": ["agent"],
@@ -820,7 +820,7 @@ Return a JSON object with:
 ```typescript
 // Another reasoning/thought
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "thought-002",
   "from": "agent",
   "kind": "reasoning/thought",
@@ -861,7 +861,7 @@ For your tip calculation: 15% of $85 is $12.75, making your total $97.75."
 ```typescript
 // Agent sends reasoning/conclusion
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "reason-end-001",
   "from": "agent",
   "kind": "reasoning/conclusion",
@@ -877,7 +877,7 @@ For your tip calculation: 15% of $85 is $12.75, making your total $97.75."
 ```typescript
 // Agent sends final response
 {
-  "protocol": "mew/v0.3",
+  "protocol": "mew/v0.4",
   "id": "response-001",
   "from": "agent",
   "to": ["user"],
@@ -1130,7 +1130,7 @@ maxIterations: 10
 - TypeScript 5.0+ (for TypeScript SDK)
 
 ### Protocol Dependencies
-- MEW Protocol v0.3
+- MEW Protocol v0.4
 - MCP (Model Context Protocol)
 
 ### Package Dependencies
@@ -1321,7 +1321,7 @@ Add state persistence:
 
 ## References
 
-- [MEW Protocol Specification v0.3](../spec/v0.3/SPEC.md)
+- [MEW Protocol Specification v0.4](../spec/v0.4/SPEC.md)
 - [MCP Specification](https://modelcontextprotocol.org)
 ### Chat Message Response Strategy
 

--- a/sdk/typescript-sdk/agent/src/MEWAgent.ts
+++ b/sdk/typescript-sdk/agent/src/MEWAgent.ts
@@ -3,7 +3,7 @@ import { Envelope, ParticipantRestartPayload } from '@mew-protocol/types';
 import { v4 as uuidv4 } from 'uuid';
 import OpenAI from 'openai';
 
-const PROTOCOL_VERSION = 'mew/v0.3';
+const PROTOCOL_VERSION = 'mew/v0.4';
 
 export interface AgentConfig extends ParticipantOptions {
   name?: string;

--- a/sdk/typescript-sdk/client/README.md
+++ b/sdk/typescript-sdk/client/README.md
@@ -205,7 +205,7 @@ client.on('reconnected', () => {});
 
 ## Protocol Version
 
-This SDK implements MEW v0.2 (moving to v0.3). See the specification for protocol details.
+This SDK implements MEW v0.4. See the specification for protocol details.
 
 ## License
 

--- a/sdk/typescript-sdk/client/src/MEWClient.ts
+++ b/sdk/typescript-sdk/client/src/MEWClient.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import WebSocket, { RawData as WebSocketData } from 'ws';
 import { Envelope, Capability } from '@mew-protocol/types';
 
-const PROTOCOL_VERSION = 'mew/v0.3';
+const PROTOCOL_VERSION = 'mew/v0.4';
 
 export interface StreamFrame {
   streamId: string;

--- a/sdk/typescript-sdk/participant/src/MEWParticipant.js
+++ b/sdk/typescript-sdk/participant/src/MEWParticipant.js
@@ -4,7 +4,7 @@ exports.MEWParticipant = exports.DiscoveryState = void 0;
 const client_1 = require("@mew-protocol/client");
 const capability_matcher_1 = require("@mew-protocol/capability-matcher");
 const uuid_1 = require("uuid");
-const PROTOCOL_VERSION = 'mew/v0.3';
+const PROTOCOL_VERSION = 'mew/v0.4';
 // Discovery state for each participant
 var DiscoveryState;
 (function (DiscoveryState) {

--- a/sdk/typescript-sdk/participant/src/MEWParticipant.ts
+++ b/sdk/typescript-sdk/participant/src/MEWParticipant.ts
@@ -14,7 +14,7 @@ import {
 import { PatternMatcher } from '@mew-protocol/capability-matcher';
 import { v4 as uuidv4 } from 'uuid';
 
-const PROTOCOL_VERSION = 'mew/v0.3';
+const PROTOCOL_VERSION = 'mew/v0.4';
 
 export interface ParticipantOptions extends ClientOptions {
   requestTimeout?: number;  // Default timeout for MCP requests

--- a/sdk/typescript-sdk/types/src/protocol.d.ts
+++ b/sdk/typescript-sdk/types/src/protocol.d.ts
@@ -1,15 +1,15 @@
 /**
  * Core MEW Protocol Types
  *
- * These types define the Multi-Entity Workspace Protocol v0.3
+ * These types define the Multi-Entity Workspace Protocol v0.4
  */
-export declare const PROTOCOL_VERSION = "mew/v0.3";
+export declare const PROTOCOL_VERSION = "mew/v0.4";
 export declare const MCP_VERSION = "2025-06-18";
 /**
  * MEW envelope - the top-level wrapper for all messages
  */
 export interface Envelope {
-    protocol: 'mew/v0.3';
+    protocol: 'mew/v0.4';
     id: string;
     ts: string;
     from: string;

--- a/sdk/typescript-sdk/types/src/protocol.js
+++ b/sdk/typescript-sdk/types/src/protocol.js
@@ -2,14 +2,14 @@
 /**
  * Core MEW Protocol Types
  *
- * These types define the Multi-Entity Workspace Protocol v0.3
+ * These types define the Multi-Entity Workspace Protocol v0.4
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.MessageKinds = exports.MCP_VERSION = exports.PROTOCOL_VERSION = void 0;
 // ============================================================================
 // Protocol Constants
 // ============================================================================
-exports.PROTOCOL_VERSION = 'mew/v0.3';
+exports.PROTOCOL_VERSION = 'mew/v0.4';
 exports.MCP_VERSION = '2025-06-18';
 // ============================================================================
 // Message Kind Constants

--- a/sdk/typescript-sdk/types/src/protocol.ts
+++ b/sdk/typescript-sdk/types/src/protocol.ts
@@ -1,14 +1,14 @@
 /**
  * Core MEW Protocol Types
  * 
- * These types define the Multi-Entity Workspace Protocol v0.3
+ * These types define the Multi-Entity Workspace Protocol v0.4
  */
 
 // ============================================================================
 // Protocol Constants
 // ============================================================================
 
-export const PROTOCOL_VERSION = 'mew/v0.3';
+export const PROTOCOL_VERSION = 'mew/v0.4';
 export const MCP_VERSION = '2025-06-18';
 
 // ============================================================================
@@ -19,7 +19,7 @@ export const MCP_VERSION = '2025-06-18';
  * MEW envelope - the top-level wrapper for all messages
  */
 export interface Envelope {
-  protocol: 'mew/v0.3';
+  protocol: 'mew/v0.4';
   id: string;
   ts: string;
   from: string;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # MEW Protocol Tests
 
-This directory contains the test suite for the MEW (Multi-Entity Workspace) Protocol v0.3 implementation.
+This directory contains the test suite for the MEW (Multi-Entity Workspace) Protocol v0.4 implementation.
 
 ## Running Tests
 
@@ -90,4 +90,4 @@ Tests use PM2 for process management and the MEW CLI to start spaces. Each test:
 3. Verifies expected outcomes
 4. Cleans up all processes and artifacts
 
-For protocol details, see the main [MEW Protocol documentation](/spec/v0.3/SPEC.md).
+For protocol details, see the main [MEW Protocol documentation](/spec/v0.4/SPEC.md).

--- a/tests/agents/control-agent.js
+++ b/tests/agents/control-agent.js
@@ -82,7 +82,7 @@ let activeStreamId = null;
 
 function sendEnvelope(envelope) {
   const fullEnvelope = {
-    protocol: 'mew/v0.3',
+    protocol: 'mew/v0.4',
     id: envelope.id || generateId('env'),
     ts: new Date().toISOString(),
     from: participantId,

--- a/tests/agents/fulfiller-participant.js
+++ b/tests/agents/fulfiller-participant.js
@@ -71,7 +71,7 @@ class FulfillerAgent extends MEWParticipant {
     console.log(`Saw proposal from ${envelope.from}, auto-fulfilling...`);
     console.log(`Proposal details: ${JSON.stringify(envelope)}`);
 
-    // In MEW v0.3, the proposal payload IS the MCP request payload
+    // In MEW v0.4, the proposal payload IS the MCP request payload
     const proposal = envelope.payload;
     if (!proposal || !proposal.method) {
       console.log('No valid MCP proposal data found in message');

--- a/tests/scenario-7-mcp-bridge/test-agent.js
+++ b/tests/scenario-7-mcp-bridge/test-agent.js
@@ -30,7 +30,7 @@ ws.on('open', () => {
   
   // Send join message per MEW v0.2 spec
   ws.send(JSON.stringify({
-    protocol: 'mew/v0.3',
+    protocol: 'mew/v0.4',
     kind: 'system/join',
     id: `join-${Date.now()}`,
     from: 'test-agent',
@@ -100,7 +100,7 @@ function runTests() {
       // Test 1: List tools
       console.log('TEST 1: Listing MCP tools...');
       ws.send(JSON.stringify({
-        protocol: 'mew/v0.3',
+        protocol: 'mew/v0.4',
         kind: 'mcp/request',
         id: `test-1-${Date.now()}`,
         from: 'test-agent',
@@ -117,7 +117,7 @@ function runTests() {
       // Test 2: Call read_file tool
       console.log('TEST 2: Reading file via MCP...');
       ws.send(JSON.stringify({
-        protocol: 'mew/v0.3',
+        protocol: 'mew/v0.4',
         kind: 'mcp/request',
         id: `test-2-${Date.now()}`,
         from: 'test-agent',
@@ -139,7 +139,7 @@ function runTests() {
       // Test 3: List directory
       console.log('TEST 3: Listing directory via MCP...');
       ws.send(JSON.stringify({
-        protocol: 'mew/v0.3',
+        protocol: 'mew/v0.4',
         kind: 'mcp/request',
         id: `test-3-${Date.now()}`,
         from: 'test-agent',

--- a/tests/scenario-8-grant/agent.js
+++ b/tests/scenario-8-grant/agent.js
@@ -70,7 +70,7 @@ ws.on('message', (data) => {
 
     // Send acknowledgment
     const ack = {
-      protocol: 'mew/v0.3',
+      protocol: 'mew/v0.4',
       id: `ack-${messageId++}`,
       ts: new Date().toISOString(),
       from: PARTICIPANT_ID,
@@ -114,7 +114,7 @@ ws.on('close', () => {
 function sendProposal(filename, content) {
   log(`Sending PROPOSAL to write "${content}" to ${filename}`);
   const proposal = {
-    protocol: 'mew/v0.3',
+    protocol: 'mew/v0.4',
     id: `proposal-${messageId++}`,
     ts: new Date().toISOString(),
     from: PARTICIPANT_ID,
@@ -138,7 +138,7 @@ function sendProposal(filename, content) {
 function sendDirectRequest(filename, content) {
   log(`Sending DIRECT REQUEST to write "${content}" to ${filename}`);
   const request = {
-    protocol: 'mew/v0.3',
+    protocol: 'mew/v0.4',
     id: `request-${messageId++}`,
     ts: new Date().toISOString(),
     from: PARTICIPANT_ID,

--- a/tests/scenario-8-grant/file-server.js
+++ b/tests/scenario-8-grant/file-server.js
@@ -66,7 +66,7 @@ ws.on('message', (data) => {
 
         // Send success response
         const response = {
-          protocol: 'mew/v0.3',
+          protocol: 'mew/v0.4',
           id: `response-${messageId++}`,
           ts: new Date().toISOString(),
           from: PARTICIPANT_ID,
@@ -91,7 +91,7 @@ ws.on('message', (data) => {
 
         // Send error response
         const errorResponse = {
-          protocol: 'mew/v0.3',
+          protocol: 'mew/v0.4',
           id: `error-response-${messageId++}`,
           ts: new Date().toISOString(),
           from: PARTICIPANT_ID,


### PR DESCRIPTION
## Summary
- update CLI, SDK, bridge, and docs to reference the MEW Protocol v0.4 release
- bump runtime constants to `mew/v0.4` across agents, clients, and tests
- add migration notes calling out remaining gaps between the implementation and the v0.4 specification

## Testing
- npm run build
- ./tests/run-all-tests.sh --no-llm --verbose

------
https://chatgpt.com/codex/tasks/task_e_68d75b23555c83259993b4bf0bee6e06