### PR TITLE
feat(cli): implement schema-driven slash autocomplete phase 1

### DIFF
--- a/cli/spec/draft/decisions/proposed/013-sac-slash-command-parameter-architecture.md
+++ b/cli/spec/draft/decisions/proposed/013-sac-slash-command-parameter-architecture.md
@@ -1,0 +1,114 @@
+# ADR-sac: Slash Command Parameter Autocomplete Architecture
+
+**Status:** Proposed
+**Date:** 2025-02-14
+**Incorporation:** Not Incorporated
+
+## Context
+
+The advanced interactive CLI currently exposes slash commands through a static array that only supports fuzzy matching on the
+full command string.【F:cli/src/ui/utils/slashCommands.js†L5-L88】【F:cli/src/ui/utils/slashCommands.js†L128-L164】 Once the user
+accepts a suggestion, the CLI inserts the command template verbatim and leaves the operator to fill in every argument manually.
+This approach breaks down for the new class of envelope-driven commands the CLI must support:
+
+- MEW envelopes contain hierarchical payloads with required, optional, and nested parameters that vary by `kind` and
+  method.【F:spec/v0.4/SPEC.md†L1-L120】
+- The CLI must surface a generic `/envelope` command capable of walking an operator through building any MEW envelope, including
+  `mcp/request` → `tool/call` flows where the valid tool list depends on the currently targeted participant and the active
+  workspace session state.
+- The CLI already tracks participants, capabilities, and tool inventories in memory while rendering the advanced UI (per ADR-007
+  and ADR-011), but the existing slash command subsystem cannot query this data because it only handles plain strings.
+
+We need an extensible design that allows static commands to be described declaratively while letting individual arguments hook
+into dynamic data sources (participants, tools, proposal IDs, stream handles, etc.). The architecture must support future message
+kinds without forcing a rewrite of the autocomplete engine.
+
+## Options Considered
+
+### Option 1: Command Schema Tree with Dynamic Resolvers (Proposed)
+
+Define each slash command as a tree of tokens. Literal tokens (e.g., `/envelope`, `kind=`) map to static strings; parameter
+nodes describe required/optional arguments and point at resolver functions that can synchronously or asynchronously produce
+suggestions. Resolvers receive the current CLI state (selected participant, cached capability map, live registry of tools from
+system/presence and capability grants) so they can surface dynamic completions. The schema tree supports nested groups to
+represent envelope payload structure (e.g., `payload.method` → `tool/call` → `payload.name`).
+
+**Pros:**
+- ✅ Single abstraction handles both static strings and dynamic parameters, so the `/envelope` command can branch based on prior
+  selections (kind → method → tool → arguments) without bespoke code paths.
+- ✅ Encourages reuse: other commands can reference the same resolver (e.g., any argument needing a participant ID shares the
+  `resolveParticipants` hook).
+- ✅ Schema data can double as documentation for `/help` and future interactive forms.
+- ✅ Supports asynchronous lookups (e.g., fetch updated tool list) while keeping the UI responsive via promise-based resolvers.
+
+**Cons:**
+- ❌ Requires refactoring the autocomplete engine to operate on token streams instead of single-string fuzzy matches.
+- ❌ Needs bridging glue between Ink components and the resolver registry to pipe live CLI state into autocomplete.
+- ❌ Additional upfront complexity—command definitions become structured JSON/TS objects instead of a simple array.
+
+### Option 2: Incremental Enhancements to Existing Fuzzy Matcher
+
+Keep the current flat list but allow templates to embed tagged placeholders (e.g., `/status <participant:dynamic>`). When the
+user navigates into a placeholder, run a resolver to show context-aware completions. Matching remains string-based: the fuzzy
+search only finds the command prefix; parameter suggestions are bolted on afterward.
+
+**Pros:**
+- ✅ Minimal rewrite; current fuzzy search remains intact for command discovery.
+- ✅ Lower initial effort for retrofitting participant/tool suggestions into a few commands.
+- ✅ Existing UI wiring (EnhancedInput) needs fewer changes.
+
+**Cons:**
+- ❌ Difficult to express branching flows like `/envelope` where later arguments depend on earlier choices and may change the
+  rest of the template entirely.
+- ❌ Placeholder parsing becomes brittle, especially for nested payloads (`payload.tool.arguments.name`).
+- ❌ Hard to reuse metadata for other surfaces (help screens, validation) because structure lives inside strings.
+- ❌ Async lookups complicate keyboard navigation because the placeholder parser must manage promise lifecycles manually.
+
+### Option 3: In-Command Interactive Wizard
+
+Trigger a mini form/wizard when a command like `/envelope` is selected. Instead of inline autocomplete, the CLI opens a dialog
+that walks the operator through each parameter with dedicated prompts, using the existing command list solely for entry-point
+selection.
+
+**Pros:**
+- ✅ Maximum flexibility for complex envelopes—can present bespoke UI per message type.
+- ✅ Avoids rewriting the slash autocomplete engine beyond launching the wizard.
+- ✅ Naturally accommodates validation and preview before submission.
+
+**Cons:**
+- ❌ Breaks the inline typing workflow established in ADR-010/011; users must switch interaction modes for complex commands.
+- ❌ Requires a second UI subsystem (dialog manager) with its own navigation, history, and error handling.
+- ❌ Harder to scale across many commands; every new envelope path demands a new wizard script.
+- ❌ Doesn’t help simpler commands that still need inline dynamic completions (e.g., `/pause <participant>`).
+
+## Decision (Proposed)
+
+Adopt **Option 1 (Command Schema Tree with Dynamic Resolvers)** as the guiding architecture. This keeps the inline typing
+experience while unlocking dynamic suggestions at any position in the command. We will:
+
+1. Replace the current array-based metadata with a typed command schema registry.
+2. Update the autocomplete engine to tokenize user input, traverse the schema, and merge literal + resolver suggestions based on
+   the cursor location.
+3. Introduce a resolver registry so command definitions can declare their dependencies (participants, tools, capability filters,
+   proposal IDs, etc.) without reaching directly into UI state objects.
+4. Back the generic `/envelope` command with nested schema nodes that mirror MEW envelope structure and delegate to resolver
+   plugins for dynamic sections (participant selection, tool discovery, context IDs, etc.).
+5. Expose the same schema metadata to `/help` so documentation stays synchronized with the autocomplete experience.
+
+This ADR remains proposed until we validate the schema shape against upcoming envelope flows and ensure it doesn’t conflict with
+other UI refactors.
+
+## Consequences
+
+- Engineering work shifts toward defining reusable resolver interfaces and bridging CLI state into the autocomplete layer.
+- Command authors get a clear extension point: add a schema node + resolver instead of editing fuzzy string lists.
+- We must create migration tooling (or manual steps) to translate existing commands (`/pause`, `/stream request`, etc.) into the
+  schema format without regressing UX.
+- Future ADRs covering UI validation or command palettes can build on the schema registry, reducing duplication.
+
+## Open Questions
+
+1. What is the minimal resolver API surface that still supports async lookups and caching for large tool catalogs?
+2. How do we version command schemas so plugins can extend them without mutating core definitions directly?
+3. Can the schema support contextual defaults (e.g., pre-selecting the participant currently focused in the signal board)?
+4. How will error handling surface when a resolver fails (tool list fetch timeout, missing permissions, etc.)?

--- a/cli/src/ui/components/EnhancedInput.js
+++ b/cli/src/ui/components/EnhancedInput.js
@@ -19,80 +19,6 @@ const { defaultKeyBindings } = require('../../config/keyBindings');
 const { getSlashCommandSuggestions } = require('../utils/slashCommands');
 const fs = require('fs');
 const path = require('path');
-
-function tokensFromCommand(commandText) {
-  if (!commandText) return [];
-  return commandText.trim().split(/\s+/);
-}
-
-function tokenMatchesSuggestion(inputToken, expectedToken) {
-  if (!inputToken || !expectedToken) return false;
-  const actual = inputToken.toLowerCase();
-  const expected = expectedToken.toLowerCase();
-  return expected.startsWith(actual) || actual.startsWith(expected);
-}
-
-function findSlashCommandArgsIndex(input, commandText) {
-  const tokens = tokensFromCommand(commandText);
-  if (!input) return 0;
-  if (tokens.length === 0) return input.length;
-
-  let idx = 0;
-  let tokenIdx = 0;
-  let tokenStart = null;
-
-  const consumeMatchedToken = () => {
-    tokenIdx += 1;
-    if (tokenIdx === tokens.length) {
-      while (idx < input.length && /\s/.test(input[idx])) {
-        idx += 1;
-      }
-      return true;
-    }
-    return false;
-  };
-
-  while (idx < input.length) {
-    const char = input[idx];
-    const isWhitespace = /\s/.test(char);
-
-    if (isWhitespace) {
-      if (tokenStart !== null) {
-        const tokenText = input.slice(tokenStart, idx);
-        if (tokenIdx < tokens.length && tokenMatchesSuggestion(tokenText, tokens[tokenIdx])) {
-          tokenStart = null;
-          idx += 1;
-          if (consumeMatchedToken()) {
-            return idx;
-          }
-          continue;
-        }
-        return tokenStart;
-      }
-      idx += 1;
-      continue;
-    }
-
-    if (tokenStart === null) {
-      tokenStart = idx;
-    }
-    idx += 1;
-  }
-
-  if (tokenStart !== null) {
-    const tokenText = input.slice(tokenStart, idx);
-    if (tokenIdx < tokens.length && tokenMatchesSuggestion(tokenText, tokens[tokenIdx])) {
-      tokenIdx += 1;
-      if (tokenIdx >= tokens.length) {
-        return idx;
-      }
-      return tokenStart;
-    }
-    return tokenStart;
-  }
-
-  return idx;
-}
 // Helper function for debug logging
 const debugLog = (message) => {
   const logFile = path.join(process.cwd(), '.mew', 'debug.log');
@@ -152,7 +78,10 @@ function EnhancedInput({
 
     const text = buffer.getText();
     if (text.trim().startsWith('/')) {
-      const matches = getSlashCommandSuggestions(text);
+      const cursorIndex = typeof buffer.getCursorIndex === 'function'
+        ? buffer.getCursorIndex()
+        : text.length;
+      const matches = getSlashCommandSuggestions({ text, cursorIndex });
       setSuggestions(matches);
       setIsAutocompleting(matches.length > 0);
       setSelectedSuggestion(0);
@@ -173,51 +102,24 @@ function EnhancedInput({
     if (suggestions.length === 0) return;
 
     const suggestion = suggestions[selectedSuggestion];
-    const template = suggestion.usage || suggestion.command;
-
     const currentText = buffer.getText();
-    const leadingWhitespaceMatch = currentText.match(/^\s*/);
-    const leadingWhitespace = leadingWhitespaceMatch ? leadingWhitespaceMatch[0] : '';
-    const trimmedInput = currentText.slice(leadingWhitespace.length);
+    const replacement = suggestion.replacement || { start: 0, end: currentText.length };
+    const start = Math.max(0, Math.min(replacement.start, currentText.length));
+    const end = Math.max(start, Math.min(replacement.end, currentText.length));
+    const insertText = typeof suggestion.insertText === 'string' ? suggestion.insertText : '';
+    const nextCursorIndex = typeof suggestion.nextCursorIndex === 'number'
+      ? suggestion.nextCursorIndex
+      : start + insertText.length;
 
-    const commandBase = template.endsWith(' ')
-      ? template
-      : `${template} `;
-
-    let newText;
-
-    if (trimmedInput.startsWith('/')) {
-      const argsIndex = findSlashCommandArgsIndex(trimmedInput, suggestion.command);
-
-      let argsStartIndex = argsIndex;
-      if (argsStartIndex === 0) {
-        const firstWhitespaceMatch = trimmedInput.match(/\s+/);
-        if (firstWhitespaceMatch) {
-          const tentativeIndex = firstWhitespaceMatch.index + firstWhitespaceMatch[0].length;
-          if (tentativeIndex < trimmedInput.length) {
-            argsStartIndex = tentativeIndex;
-          } else {
-            argsStartIndex = -1;
-          }
-        } else {
-          argsStartIndex = -1;
-        }
-      }
-
-      const remainder = argsStartIndex >= 0 && argsStartIndex < trimmedInput.length
-        ? trimmedInput.slice(argsStartIndex).replace(/^\s*/, '')
-        : '';
-
-      newText = remainder
-        ? `${leadingWhitespace}${commandBase}${remainder}`
-        : `${leadingWhitespace}${commandBase}`;
-    } else {
-      newText = `${leadingWhitespace}${commandBase}`;
-    }
+    const newText = `${currentText.slice(0, start)}${insertText}${currentText.slice(end)}`;
 
     suppressSuggestionsRef.current = true;
     buffer.setText(newText);
-    buffer.move('bufferEnd');
+    if (typeof buffer.setCursorIndex === 'function') {
+      buffer.setCursorIndex(nextCursorIndex);
+    } else {
+      buffer.move('bufferEnd');
+    }
     setIsAutocompleting(false);
     setSuggestions([]);
     setSelectedSuggestion(0);
@@ -712,11 +614,11 @@ function EnhancedInput({
 
     return React.createElement(Box, { flexDirection: 'column', marginTop: 1 },
       suggestions.slice(0, 8).map((suggestion, index) =>
-        React.createElement(Box, { key: `${suggestion.command}-${index}` },
+        React.createElement(Box, { key: suggestion.id || `${suggestion.label}-${index}` },
           React.createElement(Text, {
             color: index === selectedSuggestion ? 'cyan' : 'gray'
           },
-            `${index === selectedSuggestion ? '→' : ' '} ${suggestion.usage || suggestion.command}`
+            `${index === selectedSuggestion ? '→' : ' '} ${suggestion.label}`
           ),
           suggestion.description && React.createElement(Text, { color: 'gray' }, ` — ${suggestion.description}`)
         )

--- a/cli/src/ui/utils/slashCommands.js
+++ b/cli/src/ui/utils/slashCommands.js
@@ -1,105 +1,686 @@
 /**
- * Slash command metadata and fuzzy matching utilities for the MEW CLI.
+ * Slash command schema and autocomplete engine for the MEW CLI.
+ *
+ * Phase 1 implements schema-based traversal for existing static commands
+ * while laying the groundwork for dynamic resolvers (participants, tools, etc.).
  */
 
-const slashCommandList = [
-  { command: '/help', description: 'Show this help message', category: 'General' },
-  { command: '/verbose', description: 'Toggle verbose output', category: 'General' },
-  { command: '/streams', description: 'Toggle stream data display', category: 'General' },
-  {
-    command: '/ui board',
-    usage: '/ui board [open|close|auto]',
+const NODE_TYPES = {
+  LITERAL: 'literal',
+  CHOICE: 'choice',
+  PARAMETER: 'parameter'
+};
+
+function literal(value, meta = {}) {
+  return {
+    type: NODE_TYPES.LITERAL,
+    value,
+    description: meta.description || null,
+    optional: Boolean(meta.optional),
+    insertValue: meta.insertValue || value,
+    displayValue: meta.displayValue || value,
+    appendSpace: typeof meta.appendSpace === 'boolean' ? meta.appendSpace : undefined,
+    aliases: Array.isArray(meta.aliases) ? meta.aliases.slice() : null
+  };
+}
+
+function choice(name, options, meta = {}) {
+  return {
+    type: NODE_TYPES.CHOICE,
+    name,
+    options: Array.isArray(options)
+      ? options.map((option, index) => normalizeOption(option, index))
+      : [],
+    optional: Boolean(meta.optional),
+    description: meta.description || null,
+    placeholder: meta.placeholder || `<${name}>`,
+    appendSpace: typeof meta.appendSpace === 'boolean' ? meta.appendSpace : undefined
+  };
+}
+
+function parameter(name, options = {}) {
+  const normalizedOptions = Array.isArray(options.options)
+    ? options.options.map((option, index) => normalizeOption(option, index))
+    : null;
+
+  return {
+    type: NODE_TYPES.PARAMETER,
+    name,
+    optional: Boolean(options.optional),
+    description: options.description || null,
+    placeholder: options.placeholder || `<${name}>`,
+    resolver: typeof options.resolver === 'function' ? options.resolver : null,
+    resolverKey: options.resolverKey || null,
+    collectAs: options.collectAs || name,
+    allowUnknown: options.allowUnknown !== false,
+    variadic: Boolean(options.variadic),
+    appendSpace: typeof options.appendSpace === 'boolean' ? options.appendSpace : undefined,
+    options: normalizedOptions
+  };
+}
+
+function normalizeOption(option, index) {
+  if (typeof option === 'string') {
+    return {
+      value: option,
+      displayValue: option,
+      description: null,
+      index
+    };
+  }
+
+  if (option && typeof option === 'object') {
+    return {
+      value: option.value,
+      displayValue: option.displayValue || option.value,
+      insertValue: option.insertValue || option.value,
+      description: option.description || null,
+      index
+    };
+  }
+
+  return {
+    value: String(option),
+    displayValue: String(option),
+    description: null,
+    index
+  };
+}
+
+function createCommand(config) {
+  const sequence = Array.isArray(config.sequence) ? config.sequence : [];
+  const usage = config.usage || buildUsageFromSequence(sequence);
+
+  return {
+    id: config.id,
+    description: config.description || '',
+    category: config.category || 'General',
+    usage,
+    sequence,
+    order: typeof config.order === 'number' ? config.order : 0,
+    primary: config.primary || computePrimaryAlias(sequence),
+    summary: config.summary || config.description || '',
+    keywords: Array.isArray(config.keywords) ? config.keywords.slice() : []
+  };
+}
+
+function buildUsageFromSequence(sequence) {
+  return sequence
+    .map((node) => {
+      if (node.type === NODE_TYPES.LITERAL) {
+        return node.displayValue || node.value;
+      }
+      if (node.type === NODE_TYPES.CHOICE) {
+        const choiceValues = node.options.map(opt => opt.displayValue || opt.value).join('|');
+        return `[${choiceValues}]`;
+      }
+      if (node.type === NODE_TYPES.PARAMETER) {
+        return node.optional ? `[${node.placeholder}]` : `<${node.placeholder || node.name}>`;
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .join(' ');
+}
+
+function computePrimaryAlias(sequence) {
+  const parts = [];
+  for (const node of sequence) {
+    if (node.type !== NODE_TYPES.LITERAL) {
+      break;
+    }
+    parts.push(node.displayValue || node.value);
+  }
+  return parts.join(' ');
+}
+
+const commandDefinitions = [
+  createCommand({
+    id: 'help',
+    description: 'Show this help message',
+    category: 'General',
+    usage: '/help',
+    sequence: [literal('/help')]
+  }),
+  createCommand({
+    id: 'verbose',
+    description: 'Toggle verbose output',
+    category: 'General',
+    usage: '/verbose',
+    sequence: [literal('/verbose')]
+  }),
+  createCommand({
+    id: 'streams-toggle',
+    description: 'Toggle stream data display',
+    category: 'General',
+    usage: '/streams',
+    sequence: [literal('/streams')]
+  }),
+  createCommand({
+    id: 'ui-board-control',
     description: 'Control Signal Board visibility',
-    category: 'General'
-  },
-  { command: '/ui-clear', description: 'Clear local UI buffers', category: 'General' },
-  { command: '/ui-board', description: 'Toggle Signal Board visibility', category: 'General' },
-  { command: '/exit', description: 'Exit the application', category: 'General' },
-
-  {
-    command: '/ack',
-    usage: '/ack [selector] [status]',
+    category: 'General',
+    usage: '/ui board [open|close|auto]',
+    sequence: [
+      literal('/ui'),
+      literal('board'),
+      choice('mode', [
+        { value: 'open', description: 'Keep the Signal Board open' },
+        { value: 'close', description: 'Hide the Signal Board' },
+        { value: 'auto', description: 'Automatically toggle based on activity' }
+      ], { optional: true, description: 'Board visibility mode' })
+    ]
+  }),
+  createCommand({
+    id: 'ui-clear',
+    description: 'Clear local UI buffers',
+    category: 'General',
+    usage: '/ui-clear',
+    sequence: [literal('/ui-clear')]
+  }),
+  createCommand({
+    id: 'ui-board-toggle',
+    description: 'Toggle Signal Board visibility',
+    category: 'General',
+    usage: '/ui-board',
+    sequence: [literal('/ui-board')]
+  }),
+  createCommand({
+    id: 'exit',
+    description: 'Exit the application',
+    category: 'General',
+    usage: '/exit',
+    sequence: [literal('/exit')]
+  }),
+  createCommand({
+    id: 'ack',
     description: 'Acknowledge chat messages',
-    category: 'Chat Queue'
-  },
-  {
-    command: '/cancel',
-    usage: '/cancel [selector] [reason]',
+    category: 'Chat Queue',
+    usage: '/ack [selector] [status]',
+    sequence: [
+      literal('/ack'),
+      parameter('selector', { optional: true, description: 'Message selector', placeholder: 'selector' }),
+      parameter('status', { optional: true, description: 'Status', placeholder: 'status' })
+    ]
+  }),
+  createCommand({
+    id: 'cancel',
     description: 'Cancel reasoning or pending chats',
-    category: 'Chat Queue'
-  },
-
-  {
-    command: '/status',
-    usage: '/status <participant> [fields...]',
+    category: 'Chat Queue',
+    usage: '/cancel [selector] [reason]',
+    sequence: [
+      literal('/cancel'),
+      parameter('selector', { optional: true, description: 'Message selector', placeholder: 'selector' }),
+      parameter('reason', { optional: true, description: 'Reason', placeholder: 'reason', variadic: true })
+    ]
+  }),
+  createCommand({
+    id: 'status',
     description: 'Request participant status',
-    category: 'Participant Controls'
-  },
-  {
-    command: '/pause',
-    usage: '/pause <participant> [timeout] [reason]',
+    category: 'Participant Controls',
+    usage: '/status <participant> [fields...]',
+    sequence: [
+      literal('/status'),
+      parameter('participant', { description: 'Participant ID', placeholder: 'participant' }),
+      parameter('fields', { optional: true, description: 'Fields to request', placeholder: 'fields...', variadic: true })
+    ]
+  }),
+  createCommand({
+    id: 'pause',
     description: 'Pause a participant',
-    category: 'Participant Controls'
-  },
-  {
-    command: '/resume',
-    usage: '/resume <participant> [reason]',
+    category: 'Participant Controls',
+    usage: '/pause <participant> [timeout] [reason]',
+    sequence: [
+      literal('/pause'),
+      parameter('participant', { description: 'Participant ID', placeholder: 'participant' }),
+      parameter('timeout', { optional: true, description: 'Timeout', placeholder: 'timeout' }),
+      parameter('reason', { optional: true, description: 'Reason', placeholder: 'reason', variadic: true })
+    ]
+  }),
+  createCommand({
+    id: 'resume',
     description: 'Resume a participant',
-    category: 'Participant Controls'
-  },
-  {
-    command: '/forget',
-    usage: '/forget <participant> [oldest|newest] [count]',
+    category: 'Participant Controls',
+    usage: '/resume <participant> [reason]',
+    sequence: [
+      literal('/resume'),
+      parameter('participant', { description: 'Participant ID', placeholder: 'participant' }),
+      parameter('reason', { optional: true, description: 'Reason', placeholder: 'reason', variadic: true })
+    ]
+  }),
+  createCommand({
+    id: 'forget',
     description: 'Forget participant history',
-    category: 'Participant Controls'
-  },
-  {
-    command: '/clear',
-    usage: '/clear <participant> [reason]',
+    category: 'Participant Controls',
+    usage: '/forget <participant> [oldest|newest] [count]',
+    sequence: [
+      literal('/forget'),
+      parameter('participant', { description: 'Participant ID', placeholder: 'participant' }),
+      choice('order', [
+        { value: 'oldest', description: 'Remove oldest memories first' },
+        { value: 'newest', description: 'Remove newest memories first' }
+      ], { optional: true, description: 'History order' }),
+      parameter('count', { optional: true, description: 'Number of memories to forget', placeholder: 'count' })
+    ]
+  }),
+  createCommand({
+    id: 'clear',
     description: 'Clear a participant queue',
-    category: 'Participant Controls'
-  },
-  {
-    command: '/restart',
-    usage: '/restart <participant> [mode] [reason]',
+    category: 'Participant Controls',
+    usage: '/clear <participant> [reason]',
+    sequence: [
+      literal('/clear'),
+      parameter('participant', { description: 'Participant ID', placeholder: 'participant' }),
+      parameter('reason', { optional: true, description: 'Reason', placeholder: 'reason', variadic: true })
+    ]
+  }),
+  createCommand({
+    id: 'restart',
     description: 'Restart a participant',
-    category: 'Participant Controls'
-  },
-  {
-    command: '/shutdown',
-    usage: '/shutdown <participant> [reason]',
+    category: 'Participant Controls',
+    usage: '/restart <participant> [mode] [reason]',
+    sequence: [
+      literal('/restart'),
+      parameter('participant', { description: 'Participant ID', placeholder: 'participant' }),
+      parameter('mode', { optional: true, description: 'Restart mode', placeholder: 'mode' }),
+      parameter('reason', { optional: true, description: 'Reason', placeholder: 'reason', variadic: true })
+    ]
+  }),
+  createCommand({
+    id: 'shutdown',
     description: 'Shut down a participant',
-    category: 'Participant Controls'
-  },
-
-  {
-    command: '/stream request',
-    usage: '/stream request <participant> <direction> [description] [size=bytes]',
+    category: 'Participant Controls',
+    usage: '/shutdown <participant> [reason]',
+    sequence: [
+      literal('/shutdown'),
+      parameter('participant', { description: 'Participant ID', placeholder: 'participant' }),
+      parameter('reason', { optional: true, description: 'Reason', placeholder: 'reason', variadic: true })
+    ]
+  }),
+  createCommand({
+    id: 'stream-request',
     description: 'Request a new stream',
-    category: 'Streams'
-  },
-  {
-    command: '/stream close',
-    usage: '/stream close <streamId> [reason]',
+    category: 'Streams',
+    usage: '/stream request <participant> <direction> [description] [size=bytes]',
+    sequence: [
+      literal('/stream'),
+      literal('request'),
+      parameter('participant', { description: 'Participant ID', placeholder: 'participant' }),
+      parameter('direction', { description: 'Stream direction', placeholder: 'direction' }),
+      parameter('description', { optional: true, description: 'Description', placeholder: 'description', variadic: true }),
+      parameter('size', { optional: true, description: 'Maximum size (bytes)', placeholder: 'size=bytes' })
+    ]
+  }),
+  createCommand({
+    id: 'stream-close',
     description: 'Close an existing stream',
-    category: 'Streams'
-  },
+    category: 'Streams',
+    usage: '/stream close <streamId> [reason]',
+    sequence: [
+      literal('/stream'),
+      literal('close'),
+      parameter('streamId', { description: 'Stream identifier', placeholder: 'streamId' }),
+      parameter('reason', { optional: true, description: 'Reason', placeholder: 'reason', variadic: true })
+    ]
+  })
 ];
 
-const slashCommandGroups = ['General', 'Chat Queue', 'Participant Controls', 'Streams'];
+const commandRegistry = commandDefinitions.map((command, index) => ({
+  ...command,
+  order: index
+}));
 
-/**
- * Perform a basic fuzzy match between an input string and a command.
- * Returns a numeric score if the command matches, otherwise null.
- * Lower scores indicate better matches.
- *
- * @param {string} input - The user input.
- * @param {string} command - The command to score.
- * @returns {number|null}
- */
+const slashCommandList = commandRegistry.map((command) => ({
+  command: command.primary,
+  usage: command.usage,
+  description: command.description,
+  category: command.category
+}));
+
+const slashCommandGroups = Array.from(new Set(commandRegistry.map(cmd => cmd.category)));
+
+function tokenize(text) {
+  const tokens = [];
+  const regex = /\S+/g;
+  let match;
+
+  while ((match = regex.exec(text)) !== null) {
+    tokens.push({
+      value: match[0],
+      start: match.index,
+      end: match.index + match[0].length
+    });
+  }
+
+  return tokens;
+}
+
+function buildInputContext(text, cursorIndex) {
+  const tokens = tokenize(text);
+  const effectiveCursor = Math.max(0, Math.min(cursorIndex, text.length));
+
+  let activeIndex = tokens.length;
+  let activeToken = {
+    value: '',
+    start: effectiveCursor,
+    end: effectiveCursor,
+    prefix: '',
+    suffix: '',
+    isSynthetic: true
+  };
+
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index];
+    if (effectiveCursor < token.start) {
+      activeIndex = index;
+      break;
+    }
+    if (effectiveCursor >= token.start && effectiveCursor <= token.end) {
+      const prefixLength = Math.max(0, effectiveCursor - token.start);
+      const tokenValue = text.slice(token.start, token.end);
+      activeToken = {
+        value: tokenValue,
+        start: token.start,
+        end: token.end,
+        prefix: tokenValue.slice(0, prefixLength),
+        suffix: tokenValue.slice(prefixLength),
+        isSynthetic: false
+      };
+      activeIndex = index;
+      break;
+    }
+  }
+
+  const tokensBefore = activeToken.isSynthetic
+    ? tokens.filter(token => token.end <= activeToken.start)
+    : tokens.slice(0, activeIndex);
+
+  return {
+    text,
+    cursorIndex: effectiveCursor,
+    tokens,
+    activeToken,
+    tokensBefore
+  };
+}
+
+function matchCommand(command, context) {
+  const matchedNodes = [];
+  const parameters = {};
+  let nodeIndex = 0;
+
+  for (const token of context.tokensBefore) {
+    const tokenValue = token.value;
+    const result = consumeToken(command.sequence, nodeIndex, tokenValue);
+    if (!result) {
+      return null;
+    }
+
+    matchedNodes.push({
+      node: result.node,
+      canonicalValue: result.canonicalValue,
+      value: tokenValue,
+      option: result.option || null
+    });
+
+    if (result.parameterName) {
+      parameters[result.parameterName] = result.canonicalValue;
+    }
+
+    nodeIndex = result.nextIndex;
+  }
+
+  return {
+    nextIndex: nodeIndex,
+    matchedNodes,
+    parameters
+  };
+}
+
+function consumeToken(sequence, startIndex, tokenValue) {
+  let index = startIndex;
+
+  while (index < sequence.length) {
+    const node = sequence[index];
+    const match = matchNode(node, tokenValue);
+
+    if (match.matched) {
+      return {
+        node,
+        canonicalValue: match.canonicalValue,
+        option: match.option || null,
+        parameterName: match.parameterName || null,
+        nextIndex: index + 1
+      };
+    }
+
+    if (!node.optional) {
+      return null;
+    }
+
+    index += 1;
+  }
+
+  return null;
+}
+
+function matchNode(node, tokenValue) {
+  const value = tokenValue || '';
+
+  if (node.type === NODE_TYPES.LITERAL) {
+    const candidates = [node.value].concat(node.aliases || []);
+    const matched = candidates.some(candidate => candidate.toLowerCase() === value.toLowerCase());
+    return matched
+      ? { matched: true, canonicalValue: node.displayValue || node.value }
+      : { matched: false };
+  }
+
+  if (node.type === NODE_TYPES.CHOICE) {
+    for (const option of node.options) {
+      if (option.value.toLowerCase() === value.toLowerCase()) {
+        return {
+          matched: true,
+          canonicalValue: option.displayValue || option.value,
+          option
+        };
+      }
+    }
+    return { matched: false };
+  }
+
+  if (node.type === NODE_TYPES.PARAMETER) {
+    if (!node.allowUnknown) {
+      const options = resolveNodeOptions(node, { matchedNodes: [], parameters: {} });
+      const normalizedValue = value.toLowerCase();
+      const found = options.find(option => option.value.toLowerCase() === normalizedValue);
+      if (!found) {
+        return { matched: false };
+      }
+    }
+
+    return {
+      matched: true,
+      canonicalValue: value,
+      parameterName: node.collectAs || node.name
+    };
+  }
+
+  return { matched: false };
+}
+
+function resolveNodeOptions(node, context) {
+  if (node.type === NODE_TYPES.CHOICE) {
+    return node.options;
+  }
+
+  if (node.type === NODE_TYPES.PARAMETER) {
+    if (Array.isArray(node.options) && node.options.length > 0) {
+      return node.options;
+    }
+
+    if (typeof node.resolver === 'function') {
+      try {
+        const result = node.resolver(context) || [];
+        if (Array.isArray(result)) {
+          return result.map((option, index) => normalizeOption(option, index));
+        }
+      } catch (err) {
+        // Silently ignore resolver errors for now. Future phases can surface these.
+      }
+    }
+  }
+
+  return [];
+}
+
+function getNextNodeWithSuggestions(command, match, context) {
+  let nodeIndex = match.nextIndex;
+
+  while (nodeIndex < command.sequence.length) {
+    const node = command.sequence[nodeIndex];
+    const options = resolveNodeOptions(node, {
+      command,
+      match,
+      text: context.text,
+      cursorIndex: context.cursorIndex,
+      parameters: match.parameters
+    });
+
+    const suggestions = buildSuggestionsForNode(command, node, nodeIndex, match, context, options);
+
+    if (suggestions.length > 0) {
+      return suggestions;
+    }
+
+    if (!node.optional) {
+      break;
+    }
+
+    nodeIndex += 1;
+  }
+
+  return [];
+}
+
+function buildSuggestionsForNode(command, node, nodeIndex, match, context, options) {
+  const suggestions = [];
+  const prefixParts = match.matchedNodes.map(entry => entry.canonicalValue).filter(Boolean);
+  const activePrefix = context.activeToken.prefix || '';
+  const replacementStart = context.activeToken.start;
+  const replacementEnd = context.activeToken.end;
+  const hasRemainingNodes = sequenceHasRemainingNodes(command.sequence, nodeIndex);
+  const baseKind = nodeIndex === 0 ? 'command' : 'argument';
+  const normalizedOptions = getNodeCandidates(node, options);
+
+  normalizedOptions.forEach((option, optionIndex) => {
+    const candidateValue = option.insertValue || option.value;
+    const candidateDisplay = option.displayValue || option.value;
+    const score = computeCandidateScore(activePrefix, candidateValue, nodeIndex);
+
+    if (score === null) {
+      return;
+    }
+
+    const label = nodeIndex === 0
+      ? command.usage
+      : [...prefixParts, candidateDisplay].join(' ').trim();
+
+    const shouldAppendSpace = determineAppendSpace(node, hasRemainingNodes);
+    const needsSpace = shouldAppendSpace && context.text.slice(replacementEnd, replacementEnd + 1) !== ' ';
+    const insertText = candidateValue + (needsSpace ? ' ' : '');
+    const nextCursorIndex = replacementStart + insertText.length;
+    const description = option.description || node.description || command.description;
+
+    suggestions.push({
+      id: `${command.id}:${nodeIndex}:${candidateValue}:${optionIndex}`,
+      label,
+      description,
+      commandId: command.id,
+      commandUsage: command.usage,
+      category: command.category,
+      kind: baseKind,
+      nodeType: node.type,
+      nodeIndex,
+      optionIndex,
+      value: candidateValue,
+      displayValue: candidateDisplay,
+      insertText,
+      replacement: {
+        start: replacementStart,
+        end: replacementEnd
+      },
+      nextCursorIndex,
+      score,
+      commandOrder: command.order
+    });
+  });
+
+  return suggestions;
+}
+
+function determineAppendSpace(node, hasRemainingNodes) {
+  if (typeof node.appendSpace === 'boolean') {
+    return node.appendSpace;
+  }
+
+  if (node.type === NODE_TYPES.PARAMETER && node.variadic) {
+    return true;
+  }
+
+  return hasRemainingNodes;
+}
+
+function sequenceHasRemainingNodes(sequence, nodeIndex) {
+  for (let index = nodeIndex + 1; index < sequence.length; index++) {
+    if (sequence[index]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getNodeCandidates(node, options) {
+  if (node.type === NODE_TYPES.LITERAL) {
+    return [{
+      value: node.insertValue || node.value,
+      displayValue: node.displayValue || node.value,
+      description: node.description || null,
+      insertValue: node.insertValue || node.value,
+      index: 0
+    }];
+  }
+
+  if (node.type === NODE_TYPES.CHOICE || node.type === NODE_TYPES.PARAMETER) {
+    return options;
+  }
+
+  return [];
+}
+
+function computeCandidateScore(prefix, candidate, nodeIndex) {
+  const trimmedPrefix = prefix || '';
+
+  if (nodeIndex === 0) {
+    return fuzzyScore(trimmedPrefix, candidate);
+  }
+
+  if (!trimmedPrefix) {
+    return 0;
+  }
+
+  const candidateLower = candidate.toLowerCase();
+  const prefixLower = trimmedPrefix.toLowerCase();
+
+  if (!candidateLower.startsWith(prefixLower)) {
+    return null;
+  }
+
+  return candidateLower.length - prefixLower.length;
+}
+
 function fuzzyScore(input, command) {
-  const needle = input.trim().toLowerCase();
-  const haystack = command.toLowerCase();
+  const needle = (input || '').trim().toLowerCase();
+  const haystack = (command || '').toLowerCase();
 
   if (!needle) {
     return 0;
@@ -113,48 +694,88 @@ function fuzzyScore(input, command) {
     if (index === -1) {
       return null;
     }
-    // Penalise gaps to favour contiguous matches.
     score += index - (lastIndex + 1);
     lastIndex = index;
   }
 
-  // Small penalty for commands that are much longer than the input.
   score += (haystack.length - needle.length) * 0.01;
 
   return score;
 }
 
-/**
- * Get fuzzy-matched slash commands for the current input.
- *
- * @param {string} input - Current input buffer contents.
- * @param {number} [limit=8] - Maximum number of suggestions to return.
- * @returns {Array<{command: string, description: string, category: string}>}
- */
-function getSlashCommandSuggestions(input, limit = 8) {
-  if (!input || !input.trim().startsWith('/')) {
+function normalizeRequest(input, limitOverride) {
+  if (typeof input === 'string') {
+    return {
+      text: input,
+      cursorIndex: input.length,
+      limit: typeof limitOverride === 'number' ? limitOverride : 8,
+      context: {}
+    };
+  }
+
+  const request = input && typeof input === 'object' ? { ...input } : {};
+  const text = typeof request.text === 'string' ? request.text : '';
+  const cursorIndex = typeof request.cursorIndex === 'number' ? request.cursorIndex : text.length;
+  const limit = typeof request.limit === 'number'
+    ? request.limit
+    : (typeof limitOverride === 'number' ? limitOverride : 8);
+
+  return {
+    text,
+    cursorIndex,
+    limit,
+    context: request.context || {}
+  };
+}
+
+function getSlashCommandSuggestions(input, limitOverride) {
+  const request = normalizeRequest(input, limitOverride);
+  const text = request.text || '';
+  const trimmed = text.trim();
+
+  if (!trimmed.startsWith('/')) {
     return [];
   }
 
-  const scored = slashCommandList
-    .map((entry) => {
-      const score = fuzzyScore(input, entry.command);
-      return score === null ? null : { ...entry, score };
-    })
-    .filter(Boolean)
-    .sort((a, b) => {
-      if (a.score !== b.score) {
-        return a.score - b.score;
-      }
-      return a.command.localeCompare(b.command);
-    });
+  const context = buildInputContext(text, request.cursorIndex);
+  const suggestions = [];
 
-  return scored.slice(0, limit).map(({ score, ...entry }) => entry);
+  for (const command of commandRegistry) {
+    const match = matchCommand(command, context);
+    if (!match) {
+      continue;
+    }
+
+    const commandSuggestions = getNextNodeWithSuggestions(command, match, context);
+    suggestions.push(...commandSuggestions);
+  }
+
+  suggestions.sort((a, b) => {
+    if (a.score !== b.score) {
+      return a.score - b.score;
+    }
+    if (a.commandOrder !== b.commandOrder) {
+      return a.commandOrder - b.commandOrder;
+    }
+    if (a.nodeIndex !== b.nodeIndex) {
+      return a.nodeIndex - b.nodeIndex;
+    }
+    if (a.optionIndex !== b.optionIndex) {
+      return a.optionIndex - b.optionIndex;
+    }
+    return a.label.localeCompare(b.label);
+  });
+
+  return suggestions.slice(0, request.limit);
 }
 
 module.exports = {
+  commandRegistry,
   slashCommandList,
   slashCommandGroups,
   getSlashCommandSuggestions,
+  NODE_TYPES,
+  literal,
+  choice,
+  parameter
 };
-

--- a/cli/src/ui/utils/text-buffer.js
+++ b/cli/src/ui/utils/text-buffer.js
@@ -41,6 +41,47 @@ class TextBuffer {
   }
 
   /**
+   * Get the absolute cursor index within the buffer text
+   */
+  getCursorIndex() {
+    let index = 0;
+    for (let lineIndex = 0; lineIndex < this.cursorLine; lineIndex++) {
+      index += this.lines[lineIndex].length;
+      index += 1; // Account for newline separator
+    }
+    return index + this.cursorColumn;
+  }
+
+  /**
+   * Set cursor position from an absolute text index
+   * @param {number} index
+   */
+  setCursorIndex(index) {
+    if (typeof index !== 'number' || Number.isNaN(index)) {
+      return;
+    }
+
+    let remaining = Math.max(0, index);
+
+    for (let lineIndex = 0; lineIndex < this.lines.length; lineIndex++) {
+      const lineLength = this.lines[lineIndex].length;
+
+      if (remaining <= lineLength) {
+        this.cursorLine = lineIndex;
+        this.cursorColumn = remaining;
+        return;
+      }
+
+      // Skip newline separator
+      remaining -= lineLength + 1;
+    }
+
+    // Clamp to end of buffer if index exceeds length
+    this.cursorLine = this.lines.length - 1;
+    this.cursorColumn = this.lines[this.cursorLine].length;
+  }
+
+  /**
    * Clear the buffer
    */
   clear() {


### PR DESCRIPTION
## Summary
- replace the flat slash command metadata with a schema-driven registry and resolver hooks for existing static commands
- update the advanced input autocomplete to consume structured suggestions and replace tokens in-place using the schema output
- add cursor index helpers to the text buffer so autocomplete can restore the caret after applying a suggestion

## Testing
- npm test *(fails: scenarios 1,2,3,4,5,7; see /tmp/npm-test.log)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ee46a12c832583a6db8c23ac9f05