### PR TITLE
Convert CLI package to TypeScript build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ sdk/typescript-sdk/*/.tsbuildinfo
 sdk/typescript-sdk/*/dist/
 bridge/.tsbuildinfo
 bridge/dist/
+cli/dist/
 build-temp/
 */build-temp/
 

--- a/cli/PROGRESS.md
+++ b/cli/PROGRESS.md
@@ -36,14 +36,14 @@ Implemented Milestones 1 and 2 from ADRs 010 and 011 for enhanced terminal input
 **Objective:** Create the foundation for multi-line text editing with cursor management
 
 #### Files Created:
-- `/cli/src/ui/utils/text-buffer.js` - Core text buffer implementation (381 lines)
+- `/cli/src/ui/utils/text-buffer.ts` - Core text buffer implementation (381 lines)
   - Multi-line text management
   - Cursor position tracking
   - Word navigation logic
   - Text deletion operations (word, line-to-end, line-to-start)
   - Line wrapping for display
 
-- `/cli/src/ui/utils/textUtils.js` - Unicode and text utilities (285 lines)
+- `/cli/src/ui/utils/textUtils.ts` - Unicode and text utilities (285 lines)
   - Unicode character width calculation
   - Emoji detection and handling
   - CJK (Chinese, Japanese, Korean) wide character support
@@ -59,33 +59,33 @@ Implemented Milestones 1 and 2 from ADRs 010 and 011 for enhanced terminal input
 **Objective:** Integrate enhanced input with keyboard shortcuts into MEW CLI
 
 #### Files Created:
-- `/cli/src/ui/hooks/useKeypress.js` - Enhanced keyboard input hook (165 lines)
+- `/cli/src/ui/hooks/useKeypress.ts` - Enhanced keyboard input hook (165 lines)
   - Cross-platform key detection
   - Modifier key support (Ctrl, Alt/Option, Shift)
   - Special key handling (arrows, home/end, function keys)
 
-- `/cli/src/ui/keyMatchers.js` - Key pattern matching utilities (211 lines)
+- `/cli/src/ui/keyMatchers.ts` - Key pattern matching utilities (211 lines)
   - Pattern matching for key combinations
   - Platform-specific helpers (Mac vs Linux/Windows)
   - Common key patterns library
 
-- `/cli/src/config/keyBindings.js` - Configurable key bindings (235 lines)
+- `/cli/src/config/keyBindings.ts` - Configurable key bindings (235 lines)
   - Default key bindings for all operations
   - Human-readable key combination display
   - Conflict detection
   - Customization support
 
-- `/cli/src/ui/components/EnhancedInput.js` - Main input component (393 lines)
+- `/cli/src/ui/components/EnhancedInput.tsx` - Main input component (393 lines)
   - Integration of TextBuffer
   - Keyboard shortcut handling
   - History navigation
   - Autocomplete infrastructure (ready for implementation)
   - Multi-line mode support
 
-- `/cli/src/ui/components/SimpleInput.js` - Simplified input for debugging (32 lines)
+- `/cli/src/ui/components/SimpleInput.tsx` - Simplified input for debugging (32 lines)
 
 #### Files Modified:
-- `/cli/src/utils/advanced-interactive-ui.js`
+- `/cli/src/utils/advanced-interactive-ui.ts`
   - Integrated EnhancedInput component
   - Removed old InputComposer
   - Added command history state management

--- a/cli/bin/mew.js
+++ b/cli/bin/mew.js
@@ -10,5 +10,13 @@
  * - mew token create     - Create a test token
  */
 
-require('../src/index.js');
+try {
+  require('../dist/index.js');
+} catch (error) {
+  if (error && error.code === 'MODULE_NOT_FOUND') {
+    console.error('The MEW CLI has not been built yet. Please run "npm run build" inside the cli package.');
+    process.exit(1);
+  }
+  throw error;
+}
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -5,9 +5,19 @@
   "bin": {
     "mew": "bin/mew.js"
   },
-  "main": "src/index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
-    "test": "node tests/run-tests.js",
+    "build": "tsc -b",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && node tests/run-tests.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,md}\" \"bin/**/*.js\"",
@@ -39,7 +49,7 @@
     "ws": "^8.18.0"
   },
   "files": [
-    "src",
+    "dist",
     "bin",
     "templates",
     "README.md"
@@ -58,10 +68,12 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
+    "@types/node": "^20.14.0",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "typescript": "^5.5.0"
   }
 }

--- a/cli/spec/draft/decisions/accepted/008-f4x-safe-fifo-input-mechanism.md
+++ b/cli/spec/draft/decisions/accepted/008-f4x-safe-fifo-input-mechanism.md
@@ -261,7 +261,7 @@ echo '{"kind":"chat"}' > ./messages/001.json  # File queue
 
 #### Phase 1: HTTP Endpoint (Immediate)
 ```javascript
-// cli/src/utils/message-input.js
+// cli/src/utils/message-input.ts
 const express = require('express');
 
 function setupHttpInput(port, messageHandler) {
@@ -306,7 +306,7 @@ function setupHttpInput(port, messageHandler) {
 
 #### Phase 2: Update CLI (Immediate)
 ```javascript
-// cli/src/commands/client.js
+// cli/src/commands/client.ts
 program
   .option('--http-port <port>', 'Enable HTTP input on port')
   .option('--http-bind <address>', 'Bind address (default: 127.0.0.1)')

--- a/cli/spec/draft/decisions/accepted/009-aud-approval-dialog-ux.md
+++ b/cli/spec/draft/decisions/accepted/009-aud-approval-dialog-ux.md
@@ -587,7 +587,7 @@ This phased approach delivers immediate value while building toward sophisticate
 
 ## References
 
-- Current implementation: `/cli/src/utils/advanced-interactive-ui.js`
+- Current implementation: `/cli/src/utils/advanced-interactive-ui.ts`
 - Related issue: TODO.md line "Better fulfill UX"
 - Similar patterns: VSCode extension approval, Docker Desktop permission dialogs
 - Terminal UI best practices: https://github.com/vadimdemedes/ink

--- a/cli/spec/draft/decisions/proposed/013-sac-slash-command-parameter-architecture.md
+++ b/cli/spec/draft/decisions/proposed/013-sac-slash-command-parameter-architecture.md
@@ -7,7 +7,7 @@
 ## Context
 
 The advanced interactive CLI currently exposes slash commands through a static array that only supports fuzzy matching on the
-full command string.【F:cli/src/ui/utils/slashCommands.js†L5-L88】【F:cli/src/ui/utils/slashCommands.js†L128-L164】 Once the user
+full command string.【F:cli/src/ui/utils/slashCommands.ts†L5-L88】【F:cli/src/ui/utils/slashCommands.ts†L128-L164】 Once the user
 accepts a suggestion, the CLI inserts the command template verbatim and leaves the operator to fill in every argument manually.
 This approach breaks down for the new class of envelope-driven commands the CLI must support:
 

--- a/cli/src/commands/agent.ts
+++ b/cli/src/commands/agent.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 const { Command } = require('commander');
 const WebSocket = require('ws');
 

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 const { Command } = require('commander');
 const WebSocket = require('ws');
 const fs = require('fs');

--- a/cli/src/commands/gateway.ts
+++ b/cli/src/commands/gateway.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 const { Command } = require('commander');
 const WebSocket = require('ws');
 const express = require('express');

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-nocheck
 
 const fs = require('fs').promises;
 const path = require('path');

--- a/cli/src/commands/space.ts
+++ b/cli/src/commands/space.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 const { Command } = require('commander');
 const fs = require('fs');
 const path = require('path');

--- a/cli/src/commands/token.ts
+++ b/cli/src/commands/token.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 const { Command } = require('commander');
 
 const token = new Command('token').description('Token management');

--- a/cli/src/config/keyBindings.ts
+++ b/cli/src/config/keyBindings.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Key Bindings Configuration for MEW CLI
  *

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-nocheck
 
 const { program } = require('commander');
 const fs = require('fs');

--- a/cli/src/ui/components/EnhancedInput.tsx
+++ b/cli/src/ui/components/EnhancedInput.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Enhanced Input Component for MEW CLI
  *

--- a/cli/src/ui/components/SimpleInput.tsx
+++ b/cli/src/ui/components/SimpleInput.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Simplified Input Component for debugging
  */

--- a/cli/src/ui/hooks/useKeypress.ts
+++ b/cli/src/ui/hooks/useKeypress.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * useKeypress Hook
  *

--- a/cli/src/ui/keyMatchers.ts
+++ b/cli/src/ui/keyMatchers.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Key Matchers for Terminal Input
  *

--- a/cli/src/ui/utils/slashCommands.ts
+++ b/cli/src/ui/utils/slashCommands.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Slash command schema and autocomplete engine for the MEW CLI.
  *

--- a/cli/src/ui/utils/text-buffer.ts
+++ b/cli/src/ui/utils/text-buffer.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Text Buffer Implementation for MEW CLI
  *

--- a/cli/src/ui/utils/textUtils.ts
+++ b/cli/src/ui/utils/textUtils.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Text Utilities for Unicode and Terminal Handling
  *

--- a/cli/src/utils/advanced-interactive-ui.ts
+++ b/cli/src/utils/advanced-interactive-ui.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Advanced Interactive UI using Ink
  *

--- a/cli/src/utils/banner.ts
+++ b/cli/src/utils/banner.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * MEW Protocol Banner
  *

--- a/cli/src/utils/interactive-ui.ts
+++ b/cli/src/utils/interactive-ui.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Interactive Terminal UI
  *

--- a/cli/src/utils/message-input.ts
+++ b/cli/src/utils/message-input.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Message Input Utility
  * 

--- a/cli/src/utils/participant-resolver.ts
+++ b/cli/src/utils/participant-resolver.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Participant Resolution Logic
  *

--- a/cli/tests/debug-enhanced-input.js
+++ b/cli/tests/debug-enhanced-input.js
@@ -6,7 +6,7 @@
 
 const React = require('react');
 const { render, Box, Text } = require('ink');
-const EnhancedInput = require('../src/ui/components/EnhancedInput');
+const EnhancedInput = require('../dist/ui/components/EnhancedInput');
 
 function DebugUI() {
   const [messages, setMessages] = React.useState([]);

--- a/cli/tests/enhanced-input-demo.js
+++ b/cli/tests/enhanced-input-demo.js
@@ -14,8 +14,8 @@
 
 const React = require('react');
 const { render, Box, Text } = require('ink');
-const EnhancedInput = require('../src/ui/components/EnhancedInput');
-const { getHelpText } = require('../src/config/keyBindings');
+const EnhancedInput = require('../dist/ui/components/EnhancedInput');
+const { getHelpText } = require('../dist/config/keyBindings');
 
 /**
  * Demo Application Component

--- a/cli/tests/enhanced-input-unit-test.js
+++ b/cli/tests/enhanced-input-unit-test.js
@@ -6,10 +6,10 @@
  * Run with: node tests/enhanced-input-unit-test.js
  */
 
-const TextBuffer = require('../src/ui/utils/text-buffer');
-const { matchesKeyCombination } = require('../src/ui/hooks/useKeypress');
-const { matches, matchesAny, KeyPatterns } = require('../src/ui/keyMatchers');
-const { defaultKeyBindings, getBindingDisplay, validateBindings } = require('../src/config/keyBindings');
+const TextBuffer = require('../dist/ui/utils/text-buffer');
+const { matchesKeyCombination } = require('../dist/ui/hooks/useKeypress');
+const { matches, matchesAny, KeyPatterns } = require('../dist/ui/keyMatchers');
+const { defaultKeyBindings, getBindingDisplay, validateBindings } = require('../dist/config/keyBindings');
 
 let testsPassed = 0;
 let testsFailed = 0;

--- a/cli/tests/test-enhanced-input-integration.js
+++ b/cli/tests/test-enhanced-input-integration.js
@@ -12,7 +12,7 @@
 
 const React = require('react');
 const { render, Box, Text } = require('ink');
-const EnhancedInput = require('../src/ui/components/EnhancedInput');
+const EnhancedInput = require('../dist/ui/components/EnhancedInput');
 
 // Mock WebSocket for testing
 class MockWebSocket {

--- a/cli/tests/test-input-standalone.js
+++ b/cli/tests/test-input-standalone.js
@@ -4,7 +4,7 @@
  * Standalone test of input rendering
  */
 
-const TextBuffer = require('../src/ui/utils/text-buffer');
+const TextBuffer = require('../dist/ui/utils/text-buffer');
 
 // Test the buffer directly
 console.log('=== TextBuffer Direct Test ===');
@@ -59,7 +59,7 @@ console.log('\n✅ TextBuffer is working correctly');
 
 // Now test if the key bindings configuration loads
 console.log('\n=== Key Bindings Test ===');
-const { defaultKeyBindings } = require('../src/config/keyBindings');
+const { defaultKeyBindings } = require('../dist/config/keyBindings');
 console.log('Key bindings loaded:', Object.keys(defaultKeyBindings).length, 'bindings');
 console.log('Sample bindings:', Object.keys(defaultKeyBindings).slice(0, 5));
 

--- a/cli/tests/text-buffer-demo.js
+++ b/cli/tests/text-buffer-demo.js
@@ -18,7 +18,7 @@
  */
 
 const readline = require('readline');
-const TextBuffer = require('../src/ui/utils/text-buffer');
+const TextBuffer = require('../dist/ui/utils/text-buffer');
 
 // Create text buffer
 const buffer = new TextBuffer('Hello World!\nThis is a multi-line text buffer demo.\nTry editing this text.');

--- a/cli/tests/text-buffer.test.js
+++ b/cli/tests/text-buffer.test.js
@@ -6,8 +6,8 @@
  * Run with: node tests/text-buffer.test.js
  */
 
-const TextBuffer = require('../src/ui/utils/text-buffer');
-const textUtils = require('../src/ui/utils/textUtils');
+const TextBuffer = require('../dist/ui/utils/text-buffer');
+const textUtils = require('../dist/ui/utils/textUtils');
 
 let testsPassed = 0;
 let testsFailed = 0;

--- a/cli/tests/verify-integration.js
+++ b/cli/tests/verify-integration.js
@@ -49,57 +49,57 @@ console.log('=== Enhanced Input Integration Verification ===\n');
 // Check all component files exist
 test('Text buffer exists', () => {
   assertFileExists(
-    path.join(__dirname, '../src/ui/utils/text-buffer.js'),
+    path.join(__dirname, '../dist/ui/utils/text-buffer.js'),
     'text-buffer.js'
   );
 });
 
 test('Text utilities exist', () => {
   assertFileExists(
-    path.join(__dirname, '../src/ui/utils/textUtils.js'),
+    path.join(__dirname, '../dist/ui/utils/textUtils.js'),
     'textUtils.js'
   );
 });
 
 test('useKeypress hook exists', () => {
   assertFileExists(
-    path.join(__dirname, '../src/ui/hooks/useKeypress.js'),
+    path.join(__dirname, '../dist/ui/hooks/useKeypress.js'),
     'useKeypress.js'
   );
 });
 
 test('keyMatchers exists', () => {
   assertFileExists(
-    path.join(__dirname, '../src/ui/keyMatchers.js'),
+    path.join(__dirname, '../dist/ui/keyMatchers.js'),
     'keyMatchers.js'
   );
 });
 
 test('keyBindings config exists', () => {
   assertFileExists(
-    path.join(__dirname, '../src/config/keyBindings.js'),
+    path.join(__dirname, '../dist/config/keyBindings.js'),
     'keyBindings.js'
   );
 });
 
 test('EnhancedInput component exists', () => {
   assertFileExists(
-    path.join(__dirname, '../src/ui/components/EnhancedInput.js'),
+    path.join(__dirname, '../dist/ui/components/EnhancedInput.js'),
     'EnhancedInput.js'
   );
 });
 
 // Check modules can be loaded
 test('TextBuffer can be imported', () => {
-  assertExports('../src/ui/utils/text-buffer');
+  assertExports('../dist/ui/utils/text-buffer');
 });
 
 test('EnhancedInput can be imported', () => {
-  assertExports('../src/ui/components/EnhancedInput');
+  assertExports('../dist/ui/components/EnhancedInput');
 });
 
 test('useKeypress exports functions', () => {
-  const module = require('../src/ui/hooks/useKeypress');
+  const module = require('../dist/ui/hooks/useKeypress');
   if (!module.useKeypress || !module.matchesKeyCombination) {
     throw new Error('Missing expected exports');
   }
@@ -108,7 +108,7 @@ test('useKeypress exports functions', () => {
 // Check integration with advanced-interactive-ui.js
 test('advanced-interactive-ui imports EnhancedInput', () => {
   assertFileContains(
-    path.join(__dirname, '../src/utils/advanced-interactive-ui.js'),
+    path.join(__dirname, '../dist/utils/advanced-interactive-ui.js'),
     "require('../ui/components/EnhancedInput')",
     'EnhancedInput import'
   );
@@ -116,7 +116,7 @@ test('advanced-interactive-ui imports EnhancedInput', () => {
 
 test('advanced-interactive-ui uses EnhancedInput', () => {
   assertFileContains(
-    path.join(__dirname, '../src/utils/advanced-interactive-ui.js'),
+    path.join(__dirname, '../dist/utils/advanced-interactive-ui.js'),
     'React.createElement(EnhancedInput',
     'EnhancedInput usage'
   );
@@ -124,7 +124,7 @@ test('advanced-interactive-ui uses EnhancedInput', () => {
 
 test('Old InputComposer is removed', () => {
   const content = fs.readFileSync(
-    path.join(__dirname, '../src/utils/advanced-interactive-ui.js'),
+    path.join(__dirname, '../dist/utils/advanced-interactive-ui.js'),
     'utf8'
   );
   // Check that the old function definition is gone
@@ -135,7 +135,7 @@ test('Old InputComposer is removed', () => {
 
 test('EnhancedInput has approval dialog compatibility', () => {
   assertFileContains(
-    path.join(__dirname, '../src/utils/advanced-interactive-ui.js'),
+    path.join(__dirname, '../dist/utils/advanced-interactive-ui.js'),
     'disabled: pendingOperation !== null',
     'Dialog compatibility'
   );
@@ -143,7 +143,7 @@ test('EnhancedInput has approval dialog compatibility', () => {
 
 // Test component functionality
 test('TextBuffer supports multi-line', () => {
-  const TextBuffer = require('../src/ui/utils/text-buffer');
+  const TextBuffer = require('../dist/ui/utils/text-buffer');
   const buffer = new TextBuffer('Line1\nLine2');
   if (buffer.lines.length !== 2) {
     throw new Error('Multi-line not working');
@@ -151,7 +151,7 @@ test('TextBuffer supports multi-line', () => {
 });
 
 test('TextBuffer supports word navigation', () => {
-  const TextBuffer = require('../src/ui/utils/text-buffer');
+  const TextBuffer = require('../dist/ui/utils/text-buffer');
   const buffer = new TextBuffer('Hello World');
   buffer.cursorColumn = 0;
   buffer.move('wordRight');
@@ -161,7 +161,7 @@ test('TextBuffer supports word navigation', () => {
 });
 
 test('Key bindings include all shortcuts', () => {
-  const { defaultKeyBindings } = require('../src/config/keyBindings');
+  const { defaultKeyBindings } = require('../dist/config/keyBindings');
   const required = [
     'MOVE_WORD_LEFT',
     'MOVE_WORD_RIGHT',

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true,
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "tests", "templates"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,11 +92,13 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
+        "@types/node": "^20.14.0",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
         "eslint": "^9.35.0",
         "eslint-config-prettier": "^10.1.8",
-        "prettier": "^3.6.2"
+        "prettier": "^3.6.2",
+        "typescript": "^5.5.0"
       },
       "engines": {
         "node": ">=16.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "./sdk/typescript-sdk/client" },
     { "path": "./sdk/typescript-sdk/participant" },
     { "path": "./sdk/typescript-sdk/agent" },
-    { "path": "./bridge" }
+    { "path": "./bridge" },
+    { "path": "./cli" }
   ]
 }


### PR DESCRIPTION
## Summary
- port the CLI source tree to TypeScript files while preserving behaviour via ts-nocheck pragmas
- add a dedicated TypeScript project configuration, update package metadata, and require the compiled output from the launcher
- retarget CLI tests and documentation to reference the dist build artifacts instead of the old JavaScript sources

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbcae6e6e483259be06011cac5c101