### PR TITLE
Refactor early test scenarios for new mew package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ spaces/*/
 # Optional stylelint cache
 .stylelintcache
 
+# Test cache artifacts
+tests/.cache/
+
 # Temporary files
 tmp/
 temp/

--- a/tests/lib/mew-cli.sh
+++ b/tests/lib/mew-cli.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Ensure the local packages/mew CLI is built and linked for tests
+
+set -euo pipefail
+
+ensure_mew_cli() {
+  if [[ -n "${MEW_TESTS_CLI_READY:-}" ]]; then
+    return 0
+  fi
+
+  local repo_root
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    repo_root="${REPO_ROOT}"
+  elif [[ -n "${SCENARIO_DIR:-}" ]]; then
+    repo_root="$(cd "${SCENARIO_DIR}/../.." && pwd)"
+  else
+    repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  fi
+
+  local mew_pkg="${repo_root}/packages/mew"
+  local cache_dir="${repo_root}/tests/.cache"
+  if [[ ! -d "${mew_pkg}" ]]; then
+    echo "packages/mew not found under ${repo_root}" >&2
+    return 1
+  fi
+
+  mkdir -p "${cache_dir}"
+
+  local npm_prefix_global
+  npm_prefix_global="$(npm prefix -g)"
+  local npm_bin_global="${npm_prefix_global}/bin"
+  if [[ -n "${npm_bin_global}" && ":${PATH}:" != *":${npm_bin_global}:"* ]]; then
+    PATH="${npm_bin_global}:${PATH}"
+    export PATH
+  fi
+
+  local build_stamp="${cache_dir}/mew-cli-build.stamp"
+  local needs_build=false
+  if [[ ! -d "${mew_pkg}/dist" ]]; then
+    needs_build=true
+  elif [[ ! -f "${build_stamp}" ]]; then
+    needs_build=true
+  else
+    local newer_src
+    newer_src="$(find "${mew_pkg}/src" -type f -newer "${build_stamp}" -print -quit)"
+    if [[ -n "${newer_src}" ]]; then
+      needs_build=true
+    fi
+  fi
+
+  pushd "${mew_pkg}" >/dev/null
+
+  if [[ ! -d "node_modules" ]]; then
+    npm install >/dev/null 2>&1
+  fi
+
+  if [[ "${needs_build}" == true ]]; then
+    npm run build:all >/dev/null 2>&1
+    touch "${build_stamp}"
+  fi
+
+  popd >/dev/null
+
+  local npm_root_global
+  npm_root_global="$(npm root -g)"
+  local global_link="${npm_root_global}/@mew-protocol/mew"
+  local needs_link=true
+  if [[ -e "${global_link}" ]]; then
+    local resolved
+    resolved="$(readlink -f "${global_link}" 2>/dev/null || realpath "${global_link}" 2>/dev/null || echo "")"
+    if [[ "${resolved}" == "${mew_pkg}" ]]; then
+      needs_link=false
+    fi
+  fi
+
+  if [[ "${needs_link}" == true ]]; then
+    pushd "${mew_pkg}" >/dev/null
+    npm link >/dev/null 2>&1
+    popd >/dev/null
+  fi
+
+  if ! command -v mew >/dev/null 2>&1; then
+    echo "mew CLI not available on PATH even after linking" >&2
+    return 1
+  fi
+
+  export MEW_TESTS_CLI_READY=1
+  return 0
+}

--- a/tests/scenario-1-basic/setup.sh
+++ b/tests/scenario-1-basic/setup.sh
@@ -20,6 +20,11 @@ printf "%b\n" "${YELLOW}=== Scenario 1 Setup ===${NC}"
 printf "%b\n" "${BLUE}Workspace: ${WORKSPACE_DIR}${NC}"
 printf "%b\n" "${BLUE}Using port ${TEST_PORT}${NC}"
 
+if ! command -v mew >/dev/null 2>&1; then
+  printf "%b\n" "${YELLOW}mew CLI not found on PATH. Run via test.sh to ensure linking.${NC}" >&2
+  exit 1
+fi
+
 # Clean previous workspace if it exists
 rm -rf "${WORKSPACE_DIR}"
 mkdir -p "${WORKSPACE_DIR}/templates"

--- a/tests/scenario-1-basic/teardown.sh
+++ b/tests/scenario-1-basic/teardown.sh
@@ -4,9 +4,8 @@
 set -euo pipefail
 
 SCENARIO_DIR=${SCENARIO_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}
-REPO_ROOT=${REPO_ROOT:-"$(cd "${SCENARIO_DIR}/../.." && pwd)"}
 WORKSPACE_DIR=${WORKSPACE_DIR:-"${SCENARIO_DIR}/.workspace"}
-CLI_BIN="${REPO_ROOT}/cli/bin/mew.js"
+LIB_DIR="${SCENARIO_DIR}/../lib"
 ENV_FILE="${WORKSPACE_DIR}/workspace.env"
 
 YELLOW='\033[1;33m'
@@ -16,13 +15,19 @@ NC='\033[0m'
 printf "%b\n" "${YELLOW}=== Scenario 1 Teardown ===${NC}"
 
 if [[ -d "${WORKSPACE_DIR}" ]]; then
+  if [[ -f "${LIB_DIR}/mew-cli.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "${LIB_DIR}/mew-cli.sh"
+    ensure_mew_cli || true
+  fi
+
   if [[ -f "${ENV_FILE}" ]]; then
     # shellcheck disable=SC1090
     source "${ENV_FILE}"
   fi
 
-  if [[ -f "${CLI_BIN}" ]]; then
-    node "${CLI_BIN}" space down --space-dir "${WORKSPACE_DIR}" >/dev/null 2>&1 || true
+  if command -v mew >/dev/null 2>&1; then
+    mew space down --space-dir "${WORKSPACE_DIR}" >/dev/null 2>&1 || true
   fi
 
   rm -rf "${WORKSPACE_DIR}"

--- a/tests/scenario-1-basic/test.sh
+++ b/tests/scenario-1-basic/test.sh
@@ -11,6 +11,11 @@ export TEMPLATE_NAME="${TEMPLATE_NAME:-scenario-1-basic}"
 export SPACE_NAME="${SPACE_NAME:-scenario-1-basic}"
 export TEST_PORT="${TEST_PORT:-$((8000 + RANDOM % 1000))}"
 
+LIB_DIR="${SCENARIO_DIR}/../lib"
+# shellcheck disable=SC1091
+source "${LIB_DIR}/mew-cli.sh"
+ensure_mew_cli
+
 cleanup() {
   "${SCENARIO_DIR}/teardown.sh" || true
 }

--- a/tests/scenario-2-mcp/setup.sh
+++ b/tests/scenario-2-mcp/setup.sh
@@ -20,6 +20,11 @@ printf "%b\n" "${YELLOW}=== Scenario 2 Setup ===${NC}"
 printf "%b\n" "${BLUE}Workspace: ${WORKSPACE_DIR}${NC}"
 printf "%b\n" "${BLUE}Using port ${TEST_PORT}${NC}"
 
+if ! command -v mew >/dev/null 2>&1; then
+  printf "%b\n" "${YELLOW}mew CLI not found on PATH. Run via test.sh to ensure linking.${NC}" >&2
+  exit 1
+fi
+
 rm -rf "${WORKSPACE_DIR}"
 mkdir -p "${WORKSPACE_DIR}/templates"
 

--- a/tests/scenario-2-mcp/teardown.sh
+++ b/tests/scenario-2-mcp/teardown.sh
@@ -4,9 +4,8 @@
 set -euo pipefail
 
 SCENARIO_DIR=${SCENARIO_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}
-REPO_ROOT=${REPO_ROOT:-"$(cd "${SCENARIO_DIR}/../.." && pwd)"}
 WORKSPACE_DIR=${WORKSPACE_DIR:-"${SCENARIO_DIR}/.workspace"}
-CLI_BIN="${REPO_ROOT}/cli/bin/mew.js"
+LIB_DIR="${SCENARIO_DIR}/../lib"
 ENV_FILE="${WORKSPACE_DIR}/workspace.env"
 
 YELLOW='\033[1;33m'
@@ -16,13 +15,19 @@ NC='\033[0m'
 printf "%b\n" "${YELLOW}=== Scenario 2 Teardown ===${NC}"
 
 if [[ -d "${WORKSPACE_DIR}" ]]; then
+  if [[ -f "${LIB_DIR}/mew-cli.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "${LIB_DIR}/mew-cli.sh"
+    ensure_mew_cli || true
+  fi
+
   if [[ -f "${ENV_FILE}" ]]; then
     # shellcheck disable=SC1090
     source "${ENV_FILE}"
   fi
 
-  if [[ -f "${CLI_BIN}" ]]; then
-    node "${CLI_BIN}" space down --space-dir "${WORKSPACE_DIR}" >/dev/null 2>&1 || true
+  if command -v mew >/dev/null 2>&1; then
+    mew space down --space-dir "${WORKSPACE_DIR}" >/dev/null 2>&1 || true
   fi
 
   rm -rf "${WORKSPACE_DIR}"

--- a/tests/scenario-2-mcp/test.sh
+++ b/tests/scenario-2-mcp/test.sh
@@ -11,6 +11,11 @@ export TEMPLATE_NAME="${TEMPLATE_NAME:-scenario-2-mcp}"
 export SPACE_NAME="${SPACE_NAME:-scenario-2-mcp}"
 export TEST_PORT="${TEST_PORT:-$((8000 + RANDOM % 1000))}"
 
+LIB_DIR="${SCENARIO_DIR}/../lib"
+# shellcheck disable=SC1091
+source "${LIB_DIR}/mew-cli.sh"
+ensure_mew_cli
+
 cleanup() {
   "${SCENARIO_DIR}/teardown.sh" || true
 }

--- a/tests/scenario-3-proposals/setup.sh
+++ b/tests/scenario-3-proposals/setup.sh
@@ -20,6 +20,11 @@ printf "%b\n" "${YELLOW}=== Scenario 3 Setup ===${NC}"
 printf "%b\n" "${BLUE}Workspace: ${WORKSPACE_DIR}${NC}"
 printf "%b\n" "${BLUE}Using port ${TEST_PORT}${NC}"
 
+if ! command -v mew >/dev/null 2>&1; then
+  printf "%b\n" "${YELLOW}mew CLI not found on PATH. Run via test.sh to ensure linking.${NC}" >&2
+  exit 1
+fi
+
 rm -rf "${WORKSPACE_DIR}"
 mkdir -p "${WORKSPACE_DIR}/templates"
 

--- a/tests/scenario-3-proposals/teardown.sh
+++ b/tests/scenario-3-proposals/teardown.sh
@@ -4,9 +4,8 @@
 set -euo pipefail
 
 SCENARIO_DIR=${SCENARIO_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}
-REPO_ROOT=${REPO_ROOT:-"$(cd "${SCENARIO_DIR}/../.." && pwd)"}
 WORKSPACE_DIR=${WORKSPACE_DIR:-"${SCENARIO_DIR}/.workspace"}
-CLI_BIN="${REPO_ROOT}/cli/bin/mew.js"
+LIB_DIR="${SCENARIO_DIR}/../lib"
 ENV_FILE="${WORKSPACE_DIR}/workspace.env"
 
 YELLOW='\033[1;33m'
@@ -16,13 +15,19 @@ NC='\033[0m'
 printf "%b\n" "${YELLOW}=== Scenario 3 Teardown ===${NC}"
 
 if [[ -d "${WORKSPACE_DIR}" ]]; then
+  if [[ -f "${LIB_DIR}/mew-cli.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "${LIB_DIR}/mew-cli.sh"
+    ensure_mew_cli || true
+  fi
+
   if [[ -f "${ENV_FILE}" ]]; then
     # shellcheck disable=SC1090
     source "${ENV_FILE}"
   fi
 
-  if [[ -f "${CLI_BIN}" ]]; then
-    node "${CLI_BIN}" space down --space-dir "${WORKSPACE_DIR}" >/dev/null 2>&1 || true
+  if command -v mew >/dev/null 2>&1; then
+    mew space down --space-dir "${WORKSPACE_DIR}" >/dev/null 2>&1 || true
   fi
 
   rm -rf "${WORKSPACE_DIR}"

--- a/tests/scenario-3-proposals/test.sh
+++ b/tests/scenario-3-proposals/test.sh
@@ -11,6 +11,11 @@ export TEMPLATE_NAME="${TEMPLATE_NAME:-scenario-3-proposals}"
 export SPACE_NAME="${SPACE_NAME:-scenario-3-proposals}"
 export TEST_PORT="${TEST_PORT:-$((8000 + RANDOM % 1000))}"
 
+LIB_DIR="${SCENARIO_DIR}/../lib"
+# shellcheck disable=SC1091
+source "${LIB_DIR}/mew-cli.sh"
+ensure_mew_cli
+
 cleanup() {
   "${SCENARIO_DIR}/teardown.sh" || true
 }


### PR DESCRIPTION
## Summary
- add a shared helper that builds and links the packages/mew CLI before scenarios execute
- update scenarios 1-3 setup/teardown/orchestrator scripts to use the linked CLI and fail fast when it is missing
- ignore the new tests/.cache directory used for build timestamps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd399201f88325a1c20801b5ca7b89